### PR TITLE
chore: bump PocketCsvReader from 2.27.7 to 2.27.10

### DIFF
--- a/src/Didot.Cli/Didot.Cli.csproj
+++ b/src/Didot.Cli/Didot.Cli.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Handlebars.Net.Helpers" Version="2.4.13" />
     <PackageReference Include="Morestachio" Version="5.0.1.631" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PocketCsvReader" Version="2.27.7" />
+    <PackageReference Include="PocketCsvReader" Version="2.27.10" />
     <PackageReference Include="Scriban" Version="6.0.0" />
     <PackageReference Include="SmartFormat.NET" Version="3.5.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/src/Didot.Core/Didot.Core.csproj
+++ b/src/Didot.Core/Didot.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Handlebars.Net.Helpers" Version="2.4.13" />
     <PackageReference Include="Morestachio" Version="5.0.1.631" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PocketCsvReader" Version="2.27.7" />
+    <PackageReference Include="PocketCsvReader" Version="2.27.10" />
     <PackageReference Include="Scriban" Version="6.0.0" />
     <PackageReference Include="SmartFormat.NET" Version="3.5.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/src/Didot.Core/SourceParsers/CsvSource.cs
+++ b/src/Didot.Core/SourceParsers/CsvSource.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PocketCsvReader;
 using System.IO;
+using PocketCsvReader.Configuration;
 
 namespace Didot.Core.SourceParsers;
 public class CsvSource : ISourceParser
@@ -14,7 +15,9 @@ public class CsvSource : ISourceParser
     public DialectDescriptor Dialect { get => CsvReader.Dialect; }
 
     public CsvSource()
-        => CsvReader = new CsvReader(new CsvProfile(true));
+        => CsvReader = new CsvReaderBuilder()
+                            .WithDialect((d) => d.WithHeader(true))
+                            .Build();
 
     public CsvSource(CsvReader csvReader)
         => CsvReader = csvReader;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the external CSV processing dependency to the latest version.
- **Refactor**
	- Enhanced the CSV import mechanism with a more flexible configuration approach for improved data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->