### PR TITLE
feat: reference partials and functions in Didot.Core (only ST, Scriban and Hdb)

### DIFF
--- a/docs/_data/navigation_docs.yml
+++ b/docs/_data/navigation_docs.yml
@@ -27,6 +27,8 @@
   - configuration
   - feature-formatter
   - feature-mappings
+  - feature-partial
+  - feature-function
 
 - title: Parsers
   docs:

--- a/docs/_docs/feature-function.md
+++ b/docs/_docs/feature-function.md
@@ -1,0 +1,66 @@
+---
+title: Defining a function
+tags: [template, features]
+---
+## Overview
+
+A template function is a function defined inside a template that can render content dynamically. When passed as an argument to another function (like map, each, or custom helpers), it acts as a kind of callback, formatting or transforming values within the template itself.
+
+You define a template block or lambda that takes arguments and renders something with them. Then you pass that function to another function (e.g., a mapping function or loop).
+
+## Registering a Function
+
+To register a function, use the `AddFunction` method of an `ITemplateEngine`. The method requires:
+
+- A name for the function – the identifier for the function.
+- A function returning a string representing the function template.
+
+```csharp
+var factory = new FileBasedTemplateEngineFactory();
+var engine = factory.GetByTag(tag);
+engine.AddFunction("Hello", () => "function definition");
+```
+
+## Using Partials in Templates
+
+Once registered, functions can be applied directly in templates by referencing the function name and passing values to the parameters.
+
+### Scriban
+
+The main template is defined as,
+
+```liquid
+{% raw %}Greetings: {{ Hello(model.Name.First, model.Name.Last) }}!{% endraw %}
+```
+
+and the function itself is defined as,
+
+```text
+{%- raw -%}
+{{ func Hello(firstName, lastName) -}}
+  Mr. {{ lastName }} {{ firstName -}}
+{{ end }}
+{% endraw %}
+```
+
+### StringTemplate
+
+The main template is defined as,
+
+```text
+{% raw %}Greetings: <Hello(model.Name.First, model.Name.Last)>!{% endraw %}
+```
+
+and the function itself is defined as,
+
+```text
+{% raw %}Hello(firstName, lastName)::= Mr. <lastName> <firstName>{% endraw %}
+```
+
+### Liquid, Fluid, Handlebars, Morestachio and SmartFormat
+
+This feature is not supported.
+
+### Conclusions
+
+Template functions that accept another template function give you a clean, composable way to define how data should be rendered, and reuse that rendering logic flexibly.

--- a/docs/_docs/feature-function.md
+++ b/docs/_docs/feature-function.md
@@ -21,9 +21,13 @@ var engine = factory.GetByTag(tag);
 engine.AddFunction("Hello", () => "function definition");
 ```
 
-## Using Partials in Templates
+## Using Functions in Templates
 
-Once registered, functions can be applied directly in templates by referencing the function name and passing values to the parameters.
+Once registered, functions can be applied directly in templates by referencing the function name and passing values to the parameters. All examples below will have the same output:
+
+```text
+Greetings: Mr. Einstein Albert!
+```
 
 ### Scriban
 

--- a/docs/_docs/feature-mappings.md
+++ b/docs/_docs/feature-mappings.md
@@ -22,7 +22,7 @@ Once registered, mappings can be applied directly in templates by referencing th
 ```csharp
 var factory = new FileBasedTemplateEngineFactory();
 var engine = factory.GetByTag(tag);
-engine.AddMappings("greetings", new Dictionary<object, string>() { {"french", "Bonjour"}, {"english", "Hi"}, {"spanish", "Ola"} })
+engine.AddMappings("greetings", new Dictionary<object, string>() { {"french", "Bonjour"}, {"english", "Hi"}, {"spanish", "Ola"} });
 ```
 
 Assume the model contains a property *Language*, and a dictionary named *greetings* has been registered to provide translations. The following examples demonstrate how to apply mappings across different template engines:

--- a/docs/_docs/feature-partial.md
+++ b/docs/_docs/feature-partial.md
@@ -1,0 +1,54 @@
+---
+title: Defining a partial
+tags: [template, features]
+---
+## Overview
+
+A partial is a reusable snippet of template code that can be included or embedded within one or more templates. It allows you to extract repeated layout or formatting logic into a separate, named unit, improving both readability and maintainability.
+
+When a template includes a partial, the templating engine:
+
+1. Looks up the partial by its name
+2. Loads or renders its content
+3. Injects the rendered result into the main template at the include point
+
+## Registering a Partial
+
+To register a partial, use the `AddPartial` method of an `ITemplateEngine`. The method requires:
+
+- A name for the partial – the identifier for the partial.
+- A function returning a string representing the partial template.
+
+## Using Partials in Templates
+
+Once registered, mappings can be applied directly in templates by referencing the dictionary name.
+
+```csharp
+var factory = new FileBasedTemplateEngineFactory();
+var engine = factory.GetByTag(tag);
+engine.AddPartial("greetings", () => "Welcome");
+```
+
+In this case, at each occurrence of the partial *greetings*, it will output the text *Welcome*.
+
+### Scriban
+
+```liquid
+{% raw %}{{include 'greetings'}}, {{model.Name.First}} {{model.Name.Last}}!{% endraw %}
+```
+
+### Handlebars
+
+```handlebars
+{% raw %}{{> Greetings }}, {{model.Name.First}} {{model.Name.Last}}!{% endraw %}
+```
+
+### StringTemplate
+
+```text
+{% raw %}<Greetings()>, <model.Name.First> <model.Name.Last>!{% endraw %}
+```
+
+### Liquid, Fluid, Morestachio and SmartFormat
+
+This feature is not supported.

--- a/docs/_docs/feature-partial.md
+++ b/docs/_docs/feature-partial.md
@@ -10,7 +10,7 @@ When a template includes a partial, the templating engine:
 
 1. Looks up the partial by its name
 2. Loads or renders its content
-3. Injects the rendered result into the main template at the include point
+3. Injects the rendered result into the main template at the point of inclusion
 
 ## Registering a Partial
 
@@ -30,6 +30,10 @@ engine.AddPartial("greetings", () => "Welcome");
 ```
 
 In this case, at each occurrence of the partial *greetings*, it will output the text *Welcome*.
+
+```text
+Welcome, Albert Einstein!
+```
 
 ### Scriban
 

--- a/src/Didot.Core/ITemplateEngine.cs
+++ b/src/Didot.Core/ITemplateEngine.cs
@@ -9,6 +9,8 @@ public interface ITemplateEngine
 {
     void AddMappings(string mapKey, IDictionary<string, object> mappings);
     void AddFormatter(string name, Func<object?, string> function);
+    void AddFunction(string name, Func<string> namedTemplate);
+    void AddPartial(string name, Func<string> includedTemplate);
     string Render(string template, object model);
     string Render(Stream template, object model);
 }

--- a/src/Didot.Core/ITemplateEngine.cs
+++ b/src/Didot.Core/ITemplateEngine.cs
@@ -9,8 +9,8 @@ public interface ITemplateEngine
 {
     void AddMappings(string mapKey, IDictionary<string, object> mappings);
     void AddFormatter(string name, Func<object?, string> function);
-    void AddFunction(string name, Func<string> namedTemplate);
-    void AddPartial(string name, Func<string> includedTemplate);
+    void AddFunction(string name, Func<string> template);
+    void AddPartial(string name, Func<string> template);
     string Render(string template, object model);
     string Render(Stream template, object model);
 }

--- a/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
@@ -18,8 +18,8 @@ public abstract class BaseTemplateEngine : ITemplateEngine
 
     protected Dictionary<string, IDictionary<string, object>> Mappings { get; } = [];
     protected Dictionary<string, Func<object?, string>> Formatters { get; } = [];
-    protected Dictionary<string, Func<string>> NamedTemplates { get; } = [];
-    protected Dictionary<string, Func<string>> Includes { get; } = [];
+    protected Dictionary<string, Func<string>> Functions { get; } = [];
+    protected Dictionary<string, Func<string>> Partials { get; } = [];
 
     public virtual void AddMappings(string mapKey, IDictionary<string, object> mappings)
     {
@@ -35,14 +35,14 @@ public abstract class BaseTemplateEngine : ITemplateEngine
 
     public virtual void AddFunction(string name, Func<string> template)
     {
-        if (!NamedTemplates.TryAdd(name, template))
-            NamedTemplates[name] = template;
+        if (!Functions.TryAdd(name, template))
+            Functions[name] = template;
     }
 
     public virtual void AddPartial(string name, Func<string> template)
     {
-        if (!Includes.TryAdd(name, template))
-            Includes[name] = template;
+        if (!Partials.TryAdd(name, template))
+            Partials[name] = template;
     }
 
     public abstract string Render(string template, object model);

--- a/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using DotLiquid.Util;
 
 namespace Didot.Core.TemplateEngines;
 public abstract class BaseTemplateEngine : ITemplateEngine

--- a/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/BaseTemplateWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DotLiquid.Util;
 
 namespace Didot.Core.TemplateEngines;
 public abstract class BaseTemplateEngine : ITemplateEngine
@@ -18,6 +19,8 @@ public abstract class BaseTemplateEngine : ITemplateEngine
 
     protected Dictionary<string, IDictionary<string, object>> Mappings { get; } = [];
     protected Dictionary<string, Func<object?, string>> Formatters { get; } = [];
+    protected Dictionary<string, Func<string>> NamedTemplates { get; } = [];
+    protected Dictionary<string, Func<string>> Includes { get; } = [];
 
     public virtual void AddMappings(string mapKey, IDictionary<string, object> mappings)
     {
@@ -29,6 +32,18 @@ public abstract class BaseTemplateEngine : ITemplateEngine
     {
         if (!Formatters.TryAdd(name, function))
             Formatters[name] = function;
+    }
+
+    public virtual void AddFunction(string name, Func<string> template)
+    {
+        if (!NamedTemplates.TryAdd(name, template))
+            NamedTemplates[name] = template;
+    }
+
+    public virtual void AddPartial(string name, Func<string> template)
+    {
+        if (!Includes.TryAdd(name, template))
+            Includes[name] = template;
     }
 
     public abstract string Render(string template, object model);

--- a/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
@@ -19,6 +19,10 @@ public class DotLiquidWrapper : BaseTemplateEngine
 
     public override void AddFormatter(string name, Func<object?, string> function)
         => throw new NotImplementedException();
+    public override void AddFunction(string name, Func<string> template)
+        => throw new NotImplementedException();
+    public override void AddPartial(string name, Func<string> template)
+        => throw new NotImplementedException();
 
     public override string Render(string source, object model)
     {

--- a/src/Didot.Core/TemplateEngines/FluidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/FluidWrapper.cs
@@ -6,6 +6,8 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
 using SmartFormat.Core.Extensions;
 
 namespace Didot.Core.TemplateEngines;
@@ -20,6 +22,12 @@ public class FluidWrapper : BaseTemplateEngine
     public FluidWrapper(TemplateConfiguration configuration)
         : base(configuration)
     { }
+
+    public override void AddFunction(string name, Func<string> template)
+        => throw new NotImplementedException();
+
+    public override void AddPartial(string name, Func<string> template)
+        => throw new NotImplementedException();
 
     public override string Render(string source, object model)
     {

--- a/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
@@ -34,7 +34,7 @@ public class HandlebarsWrapper : BaseTemplateEngine
         using var reader = new StreamReader(stream);
         var templateInstance = handlebarsContext.Compile(reader);
 
-        foreach (var include in Includes)
+        foreach (var include in Partials)
             handlebarsContext.RegisterTemplate(include.Key, include.Value.Invoke());
 
         using var writer = new StringWriter(); // StringWriter as TextWriter for output

--- a/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
@@ -17,6 +17,8 @@ public class HandlebarsWrapper : BaseTemplateEngine
     public HandlebarsWrapper(TemplateConfiguration configuration)
         : base(configuration)
     { }
+    public override void AddFunction(string name, Func<string> template)
+        => throw new NotImplementedException();
 
     public override string Render(string template, object model)
     {
@@ -31,6 +33,9 @@ public class HandlebarsWrapper : BaseTemplateEngine
 
         using var reader = new StreamReader(stream);
         var templateInstance = handlebarsContext.Compile(reader);
+
+        foreach (var include in Includes)
+            handlebarsContext.RegisterTemplate(include.Key, include.Value.Invoke());
 
         using var writer = new StringWriter(); // StringWriter as TextWriter for output
         templateInstance(writer, model);

--- a/src/Didot.Core/TemplateEngines/MorestachioWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/MorestachioWrapper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Morestachio;
+using Morestachio.Framework;
 using Morestachio.Rendering;
 
 namespace Didot.Core.TemplateEngines;
@@ -17,6 +18,11 @@ public class MorestachioWrapper : BaseTemplateEngine
     public MorestachioWrapper(TemplateConfiguration configuration)
         : base(configuration)
     { }
+    public override void AddFunction(string name, Func<string> template)
+        => throw new NotImplementedException();
+
+    public override void AddPartial(string name, Func<string> template)
+        => throw new NotImplementedException();
 
     public override string Render(string template, object model)
     {

--- a/src/Didot.Core/TemplateEngines/MorestachioWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/MorestachioWrapper.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Morestachio;
-using Morestachio.Framework;
 using Morestachio.Rendering;
 
 namespace Didot.Core.TemplateEngines;

--- a/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
@@ -41,17 +41,17 @@ public class ScribanWrapper : BaseTemplateEngine
         foreach (var (funcName, dict) in Mappings)
             scriptObject.Import(funcName, (string value) => map(dict, value));
 
-        if (NamedTemplates.Count > 0)
+        if (Functions.Count > 0)
         {
             var include = string.Empty;
-            foreach (var name in NamedTemplates.Keys)
+            foreach (var name in Functions.Keys)
                 include += $"{{{{ include '{name}' ~}}}}\r\n";
 
             template = include + template;
         }
 
         var context = Configuration.HtmlEncode ? new HtmlEncodeTemplateContext() : new TemplateContext();
-        var merged = NamedTemplates.Concat(Includes).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var merged = Functions.Concat(Partials).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         var templateLoader = new InlineIncludeTemplateLoader(merged);
         context.TemplateLoader = templateLoader;
         context.PushGlobal(scriptObject);

--- a/src/Didot.Core/TemplateEngines/SmartFormatWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/SmartFormatWrapper.cs
@@ -21,6 +21,10 @@ public class SmartFormatWrapper : BaseTemplateEngine
         => throw new NotImplementedException();
     public override void AddMappings(string mapKey, IDictionary<string, object> mappings)
         => throw new NotImplementedException();
+    public override void AddPartial(string name, Func<string> template)
+        => throw new NotImplementedException();
+    public override void AddFunction(string name, Func<string> template)
+        => throw new NotImplementedException();
 
     public override string Render(string template, object model)
         => Smart.Format(template, model);

--- a/src/Didot.Core/TemplateEngines/StringTemplateWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/StringTemplateWrapper.cs
@@ -42,7 +42,7 @@ public class StringTemplateWrapper : BaseTemplateEngine
             templateInstance.Group.RegisterRenderer(typeof(object), new RendererWrapper(renderer));
         }
 
-        foreach (var namedTemplate in NamedTemplates)
+        foreach (var namedTemplate in Functions)
         {
             var content = namedTemplate.Value.Invoke();
             if (TryParseTemplate(content, out var name, out var arguments, out var text))
@@ -55,7 +55,7 @@ public class StringTemplateWrapper : BaseTemplateEngine
                 templateInstance.Group.DefineTemplate(namedTemplate.Key, content);
         }
 
-        foreach (var include in Includes)
+        foreach (var include in Partials)
             templateInstance.Group.DefineTemplate(include.Key, include.Value.Invoke());
 
         return templateInstance.Render();

--- a/testing/Didot.Core.Testing/TemplateEngines/BaseTemplateWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/BaseTemplateWrapperTests.cs
@@ -137,4 +137,35 @@ public abstract class BaseTemplateWrapperTests
         var result = engine.Render(stream, new { model });
         Assert.That(result, Is.EqualTo("Greetings: ALICE!"));
     }
+
+    [Test]
+    public abstract void Render_NamedTemplateFunction_Successful();
+    public abstract void Render_NamedTemplateRename_Successful();
+    
+    protected void Render_NamedTemplate_Successful(string template, KeyValuePair<string, string> namedTemplate)
+    {
+        var engine = GetEngine();
+        var name = new Dictionary<string, object>()
+            { { "First", "Albert"}, {"Last", "Einstein" } };
+        var model = new Dictionary<string, object>()
+            { { "Name", name } };
+        engine.AddFunction(namedTemplate.Key, () => namedTemplate.Value);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(template));
+        var result = engine.Render(stream, new { model });
+        Assert.That(result, Is.EqualTo("Greetings: Mr. Einstein Albert!"));
+    }
+
+    public abstract void Render_Partial_Successful();
+    protected void Render_Partial_Successful(string template, KeyValuePair<string, string> includedTemplate)
+    {
+        var engine = GetEngine();
+        var name = new Dictionary<string, object>()
+            { { "First", "Albert"}, {"Last", "Einstein" } };
+        var model = new Dictionary<string, object>()
+            { { "Name", name } };
+        engine.AddPartial(includedTemplate.Key, () => includedTemplate.Value);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(template));
+        var result = engine.Render(stream, new { model });
+        Assert.That(result, Is.EqualTo("Welcome, Albert Einstein!"));
+    }
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/DotLiquidWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/DotLiquidWrapperTests.cs
@@ -54,4 +54,16 @@ public class DotLiquidWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Assert.Ignore("DotLiquid wrapper does not support formatter");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Assert.Ignore("DotLiquid wrapper does not support named templates");
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Assert.Ignore("DotLiquid wrapper does not support partials");
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("DotLiquid wrapper does not support named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/FluidWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/FluidWrapperTests.cs
@@ -54,4 +54,16 @@ public class FluidWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Render_Formatter_Successful("Greetings: {{model.Name | upper}}");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Assert.Ignore("Fluid wrapper does not support named templates");
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Assert.Ignore("Fluid wrapper does not support partials");
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("Fluid wrapper does not support named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/HandlebarsWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/HandlebarsWrapperTests.cs
@@ -55,4 +55,17 @@ public class HandlebarsWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Render_Formatter_Successful("Greetings: {{upper model.Name}}");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Assert.Ignore("Handlebars wrapper does not support named templates");
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Render_Partial_Successful("{{> Greetings }}, {{model.Name.First}} {{model.Name.Last}}!",
+            new KeyValuePair<string, string>("Greetings", "Welcome"));
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("Handlebars wrapper does not support named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/MorestachioWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/MorestachioWrapperTests.cs
@@ -54,4 +54,16 @@ public class MorestachioWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Render_Formatter_Successful("Greetings: {{model.Name.upper()}}");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Assert.Ignore("Morestachio wrapper does not support named templates");
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Assert.Ignore("Morestachio wrapper does not support partials");
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("Morestachio wrapper does not support named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/ScribanWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/ScribanWrapperTests.cs
@@ -56,4 +56,18 @@ public class ScribanWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Render_Formatter_Successful("Greetings: {{model.Name | upper}}");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Render_NamedTemplate_Successful("Greetings: {{ Hello(model.Name.First, model.Name.Last) }}!",
+            new KeyValuePair<string, string>("Hello", "{{ func Hello(firstName, lastName) -}}\r\n\tMr. {{ lastName }} {{ firstName -}}\r\n{{ end }}"));
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Render_Partial_Successful("{{ include 'Hello' }}, {{ model.Name.First }} {{ model.Name.Last}}!",
+            new KeyValuePair<string, string>("Hello", "Welcome"));
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("Scriban wrapper does not support fully named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/SmartFormatWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/SmartFormatWrapperTests.cs
@@ -54,4 +54,16 @@ public class SmartFormatWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Assert.Ignore("SmartFormat wrapper does not support formatter");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Assert.Ignore("SmartFormat wrapper does not support named templates");
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Assert.Ignore("SmartFormat wrapper does not support partials");
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Assert.Ignore("SmartFormat wrapper does not support named templates");
 }

--- a/testing/Didot.Core.Testing/TemplateEngines/StringTemplateWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/StringTemplateWrapperTests.cs
@@ -55,4 +55,19 @@ public class StringTemplateWrapperTests : BaseTemplateWrapperTests
     [Test]
     public override void Render_Formatter_Successful()
         => Render_Formatter_Successful("Greetings: <model.Name; format=\"upper\">");
+
+    [Test]
+    public override void Render_NamedTemplateFunction_Successful()
+        => Render_NamedTemplate_Successful("Greetings: <Hello(model.Name.First, model.Name.Last)>!",
+            new KeyValuePair<string, string>("Hello", "Hello(firstName, lastName)::= Mr. <lastName> <firstName>"));
+
+    [Test]
+    public override void Render_Partial_Successful()
+        => Render_Partial_Successful("<Greetings()>, <model.Name.First> <model.Name.Last>!",
+            new KeyValuePair<string, string>("Greetings", "Welcome"));
+
+    [Test]
+    public override void Render_NamedTemplateRename_Successful()
+        => Render_NamedTemplate_Successful("Greetings: <Hello(model.Name.First, model.Name.Last)>!",
+            new KeyValuePair<string, string>("Hi", "Hello(firstName, lastName)::= Mr. <lastName> <firstName>"));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering and rendering named template functions and partial templates in the templating engine, with usage examples and documentation for supported engines.
- **Documentation**
  - Introduced new documentation pages explaining template functions and partials, including usage instructions and examples for various template engines.
  - Updated navigation and fixed a minor syntax issue in code examples.
- **Tests**
  - Expanded test coverage for named template functions and partials, including new tests and explicit marking of unsupported features in specific template engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->