### PR TITLE
fix: apply Options to StringTemplate wrapper and stop to throw when using Configuration

### DIFF
--- a/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
@@ -32,9 +32,6 @@ public class DotLiquidWrapper : BaseTemplateEngine
         foreach (var (dictName, dictValues) in Mappings)
             hash[dictName] = dictValues;
 
-        if (Configuration.HtmlEncode)
-            throw new NotImplementedException();
-
         return templateInstance.Render(hash);
     }
 

--- a/src/Didot.Core/TemplateEngines/StringTemplateWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/StringTemplateWrapper.cs
@@ -32,10 +32,7 @@ public class StringTemplateWrapper : BaseTemplateEngine
 
     public override string Render(string template, object model)
     {
-        if (Configuration.HtmlEncode)
-            throw new NotImplementedException();
-
-        var templateInstance = new Template(template);
+        var templateInstance = new Template(template, Options.Delimiters.Left, Options.Delimiters.Right);
         var extractedModel = model.GetType().GetProperty("model")?.GetValue(model) ?? model;
         templateInstance.Add("model", extractedModel);
         foreach (var (key, value) in Mappings)

--- a/testing/Didot.Core.Testing/TemplateEngines/BaseTemplateWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/BaseTemplateWrapperTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
 using NUnit.Framework;
 
 namespace Didot.Core.Testing.TemplateEngines;
@@ -10,12 +11,24 @@ public abstract class BaseTemplateWrapperTests
 {
     protected abstract ITemplateEngine GetEngine();
     protected abstract ITemplateEngine GetEngine(TemplateConfiguration config);
+    protected abstract ITemplateEngine GetEngine(ITemplateEngineOptions options);
 
     [Test]
     public abstract void Render_SingleProperty_Successful();
     protected void Render_SingleProperty_Successful(string template)
     {
         var engine = GetEngine();
+        var model = new Dictionary<string, object>()
+            { { "Name", "World"} };
+        var result = engine.Render(template, new { model });
+        Assert.That(result, Is.EqualTo("Hello World"));
+    }
+
+    [Test]
+    public abstract void Render_SinglePropertyWithOptions_Successful();
+    protected void Render_SinglePropertyWithOptions_Successful(string template, ITemplateEngineOptions options)
+    {
+        var engine = GetEngine(options);
         var model = new Dictionary<string, object>()
             { { "Name", "World"} };
         var result = engine.Render(template, new { model });

--- a/testing/Didot.Core.Testing/TemplateEngines/DotLiquidWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/DotLiquidWrapperTests.cs
@@ -14,10 +14,16 @@ public class DotLiquidWrapperTests : BaseTemplateWrapperTests
         => new DotLiquidWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new DotLiquidWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {{model.Name}}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("DotLiquid wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/FluidWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/FluidWrapperTests.cs
@@ -14,10 +14,16 @@ public class FluidWrapperTests : BaseTemplateWrapperTests
         => new FluidWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new FluidWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {{model.Name}}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("Fluid wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/HandlebarsWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/HandlebarsWrapperTests.cs
@@ -15,10 +15,16 @@ public class HandlebarsWrapperTests : BaseTemplateWrapperTests
         => new HandlebarsWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new HandlebarsWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {{model.Name}}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("Handlebars wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/MorestachioWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/MorestachioWrapperTests.cs
@@ -14,10 +14,16 @@ public class MorestachioWrapperTests : BaseTemplateWrapperTests
         => new MorestachioWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new MorestachioWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {{model.Name}}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("Morestachio wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/ScribanWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/ScribanWrapperTests.cs
@@ -16,10 +16,16 @@ public class ScribanWrapperTests : BaseTemplateWrapperTests
         => new ScribanWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new ScribanWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {{model.Name}}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("Scriban wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/SmartFormatWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/SmartFormatWrapperTests.cs
@@ -14,10 +14,16 @@ public class SmartFormatWrapperTests : BaseTemplateWrapperTests
         => new SmartFormatWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new SmartFormatWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => throw new NotSupportedException();
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello {model.Name}");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Assert.Ignore("SmartFormat wrapper does not support options");
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()

--- a/testing/Didot.Core.Testing/TemplateEngines/StringTemplateWrapperTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/StringTemplateWrapperTests.cs
@@ -15,10 +15,16 @@ public class StringTemplateWrapperTests : BaseTemplateWrapperTests
         => new StringTemplateWrapper();
     protected override ITemplateEngine GetEngine(TemplateConfiguration config)
         => new StringTemplateWrapper(config);
+    protected override ITemplateEngine GetEngine(ITemplateEngineOptions options)
+        => new StringTemplateWrapper((StringTemplateOptions)options);
 
     [Test]
     public override void Render_SingleProperty_Successful()
         => Render_SingleProperty_Successful("Hello <model.Name>");
+
+    [Test]
+    public override void Render_SinglePropertyWithOptions_Successful()
+        => Render_SinglePropertyWithOptions_Successful("Hello $model.Name$", new StringTemplateOptions(new StringTemplateOptions.CharCouple('$', '$')));
 
     [Test]
     public override void RenderWithoutEncode_QuotedProperty_Successful()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved template rendering by removing unsupported checks for HTML encoding, allowing templates to render regardless of encoding settings.

- **Tests**
  - Enhanced test coverage for template engines by introducing new tests for rendering with engine options.
  - Clearly marked and skipped tests for template engines that do not support custom options, improving test clarity and accuracy.
  - Added support for testing custom delimiters in template rendering for compatible engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->