### PR TITLE
feat: cached template rendering

### DIFF
--- a/docs/_data/navigation_docs.yml
+++ b/docs/_data/navigation_docs.yml
@@ -27,6 +27,7 @@
   - engine-builder
   - engine-factory
   - engine-configuration
+  - engine-renderer
   - feature-formatter
   - feature-mappings
   - feature-partial

--- a/docs/_docs/engine-renderer.md
+++ b/docs/_docs/engine-renderer.md
@@ -1,0 +1,80 @@
+---
+title: Cached Template Rendering
+tags: [template, features]
+---
+## Overview
+
+The `IRenderer` interface defines a contract for rendering a template **with a model**, while **reusing the expensive setup parts** of the rendering process, such as template parsing and context binding.
+
+It enables you to prepare a template **once**, bind the rendering context, and render it multiple times efficiently with different data models.
+
+```csharp
+public interface IRenderer
+{
+    string Render(object model);
+}
+```
+
+Each `ITemplateEngine` implementation builds an `IRenderer` instance that:
+
+- Compiles or parses the template once
+- Initializes engine-specific context only once (if applicable)
+- Reuses the compiled representation for multiple `Render(...)` calls
+
+This reduces runtime overhead and improves performance in scenarios like batch processing or repeated rendering of the same structure.
+
+### Why Use Cached Rendering?
+
+| Aspect                | `ITemplateEngine.Render(...)`      | `IRenderer.Render(...)`                 |
+|-----------------------|-------------------------------------|------------------------------------------|
+| **Performance**       | Re-compiles template and context every time | ✅ Caches parsed/compiled templates        |
+| **Context Reuse**     | Rebuilds context per call            | ✅ Caches context creation logic (where supported) |
+| **Efficiency**        | Suitable for one-off rendering       | ✅ Optimized for many renders with same template |
+| **Memory**            | Reallocates internals each call      | ✅ Shares compiled structures where supported |
+
+## Render Pipeline: What Gets Cached?
+
+The rendering process involves three core elements:
+
+1. **Compiled Template**: The parsed, compiled version of the template source string.
+2. **Rendering Context**: Template-specific state (partials, formatters, mappings).
+3. **Model Binding**: The actual input data used at render time.
+
+Here's a breakdown of what is cached and what is created per call for each template engine:
+
+| Engine         | Compiled Template ✅ | Context Reuse 🔄                | Notes                                                                 |
+|----------------|----------------------|----------------------------------|-----------------------------------------------------------------------|
+| **Scriban**       | ✅ `Template.Parse()`        | ✅ via `TemplateContext` factory | Full reuse of compiled template and shared context strategy          |
+| **SmartFormat**   | ❌ (uses plain string)       | ❌ none                         | No pre-compilation or context reuse                                  |
+| **StringTemplate**| ✅ `CompiledTemplate`        | ✅ via `TemplateGroup`          | Group holds shared templates and compiled representation             |
+| **Morestachio**   | ✅ Renderer and AST cached    | ✅ via `IRenderer`              | Parser + compiled renderer retained                                  |
+| **Handlebars**    | ✅ Compiled delegate          | ✅ if `IHandlebars` reused      | Parser + compiled renderer       |
+| **Fluid**         | ✅ `IFluidTemplate`           | ✅ `TemplateContext` per model  | Efficient reuse with pre-compiled structure                          |
+| **DotLiquid**     | ✅ `Template.Parse()`         | ❌ `Hash` is recreated          | Context is built fresh each time unless you reuse `Hash` manually    |
+
+> ✅ **Compiled Template**: Caching avoids re-parsing the same template string  
+> 🔄 **Context Reuse**: Shared context (partials, helpers) setup — varies by engine  
+
+**Model Binding**, always occurs per render call — this is never cached.
+
+## Example Usage
+
+If you plan to render the same template multiple times (with different models), **use `Prepare(...)` from an `ITemplatEngine` to get an `IRenderer`**, then call `.Render(model)` on it. This avoids redundant parsing, compiling, or binding overhead.
+
+```csharp
+// Prepare once
+var factory = TemplateEngineFactory.Default;
+var engine = factory.Create(".scriban");
+var renderer = engine.Prepare("Hello {{ model.Name }}");
+
+// Render many times
+var result1 = renderer.Render(new { Name = "Alice" });
+var result2 = renderer.Render(new { Name = "Bob" });
+```
+
+## Summary
+
+- `IRenderer` is a high-performance rendering abstraction designed for **template reuse**
+- It avoids re-parsing or re-binding context on every render
+- Ideal when rendering the same template repeatedly with different data
+- Backed by engine-specific optimizations (e.g., compiled Scriban templates, Fluid parsing, StringTemplate groups)

--- a/src/Didot.Core/IRenderer.cs
+++ b/src/Didot.Core/IRenderer.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotLiquid;
+
+namespace Didot.Core;
+public interface IRenderer
+{
+    string Render(object model);
+}

--- a/src/Didot.Core/ITemplateEngine.cs
+++ b/src/Didot.Core/ITemplateEngine.cs
@@ -14,4 +14,5 @@ public interface ITemplateEngine
     void AddPartial(string name, Func<string> template);
     string Render(string template, object model);
     string Render(Stream template, object model);
+    IRenderer Prepare(string template);
 }

--- a/src/Didot.Core/TemplateEngines/BaseTemplateEngine.cs
+++ b/src/Didot.Core/TemplateEngines/BaseTemplateEngine.cs
@@ -9,11 +9,11 @@ public abstract class BaseTemplateEngine : ITemplateEngine
 {
     public TemplateConfiguration Configuration { get; }
 
-    public BaseTemplateEngine()
+    protected BaseTemplateEngine()
         : this(new TemplateConfiguration())
     { }
 
-    public BaseTemplateEngine(TemplateConfiguration configuration)
+    protected BaseTemplateEngine(TemplateConfiguration configuration)
         => Configuration = configuration;
 
     protected Dictionary<string, IDictionary<string, object>> Mappings { get; } = [];
@@ -46,6 +46,6 @@ public abstract class BaseTemplateEngine : ITemplateEngine
     }
 
     public abstract string Render(string template, object model);
-    public abstract string Render(Stream stream, object model);
+    public abstract string Render(Stream template, object model);
     public abstract IRenderer Prepare(string template);
 }

--- a/src/Didot.Core/TemplateEngines/BaseTemplateEngine.cs
+++ b/src/Didot.Core/TemplateEngines/BaseTemplateEngine.cs
@@ -47,4 +47,5 @@ public abstract class BaseTemplateEngine : ITemplateEngine
 
     public abstract string Render(string template, object model);
     public abstract string Render(Stream stream, object model);
+    public abstract IRenderer Prepare(string template);
 }

--- a/src/Didot.Core/TemplateEngines/DotLiquidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidRenderer.cs
@@ -9,15 +9,17 @@ using DotLiquid;
 namespace Didot.Core.TemplateEngines;
 internal class DotLiquidRenderer : IRenderer
 {
-    private readonly Template _template;
+    private readonly string _template;
+    private Template? _compiledTemplate;
     private readonly Func<object, Hash> _createContext;
 
-    public DotLiquidRenderer(Template template, Func<object, Hash> createContext)
+    public DotLiquidRenderer(string template, Func<object, Hash> createContext)
         => (_template, _createContext) = (template, createContext);
 
     public string Render(object model)
     {
+        _compiledTemplate ??= Template.Parse(_template);
         var context = _createContext(model);
-        return _template.Render(context);
+        return _compiledTemplate.Render(context);
     }
 }

--- a/src/Didot.Core/TemplateEngines/DotLiquidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidRenderer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using DotLiquid;
+
+namespace Didot.Core.TemplateEngines;
+internal class DotLiquidRenderer : IRenderer
+{
+    private readonly Template _template;
+    private readonly Func<object, Hash> _createContext;
+
+    public DotLiquidRenderer(Template template, Func<object, Hash> createContext)
+        => (_template, _createContext) = (template, createContext);
+
+    public string Render(object model)
+    {
+        var context = _createContext(model);
+        return _template.Render(context);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
@@ -57,7 +57,7 @@ public class DotLiquidWrapper : BaseTemplateEngine
 
     public override IRenderer Prepare(string template)
     {
-        return new DotLiquidRenderer(Template.Parse(template), (model) => CreateContext(model));
+        return new DotLiquidRenderer(template, CreateContext);
     }
 
     protected virtual Hash CreateContext(object model)

--- a/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/DotLiquidWrapper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DotLiquid;
+using SmartFormat.Core.Extensions;
 
 namespace Didot.Core.TemplateEngines;
 public class DotLiquidWrapper : BaseTemplateEngine
@@ -52,5 +53,31 @@ public class DotLiquidWrapper : BaseTemplateEngine
         using var reader = new StreamReader(stream);
         var template = reader.ReadToEnd();
         return Render(template, model);
+    }
+
+    public override IRenderer Prepare(string template)
+    {
+        return new DotLiquidRenderer(Template.Parse(template), (model) => CreateContext(model));
+    }
+
+    protected virtual Hash CreateContext(object model)
+    {
+        Hash hash;
+        if (!Configuration.WrapAsModel && model is IDictionary<string, object?> dict)
+        {
+            hash = Hash.FromDictionary(dict);
+        }
+        else
+        {
+            var isAlreadyWrapped = model.GetType().GetProperty("model") != null;
+            if (!isAlreadyWrapped)
+                model = new { model };
+            hash = Hash.FromAnonymousObject(model);
+        }
+
+        foreach (var (dictName, dictValues) in Mappings)
+            hash[dictName] = dictValues;
+
+        return hash;
     }
 }

--- a/src/Didot.Core/TemplateEngines/FluidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/FluidRenderer.cs
@@ -5,22 +5,30 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid;
+using Fluid.Values;
 
 namespace Didot.Core.TemplateEngines;
 internal class FluidRenderer : IRenderer
 {
-    private readonly IFluidTemplate _template;
+    private readonly string _template;
+    private IFluidTemplate? _compiledTemplate;
     private readonly Func<object, TemplateContext> _createContext;
     private readonly TextEncoder? _encoder;
 
-    public FluidRenderer(IFluidTemplate template, Func<object, TemplateContext> createContext, TextEncoder? encoder = null)
+    public FluidRenderer(string template, Func<object, TemplateContext> createContext, TextEncoder? encoder = null)
         => (_template, _createContext, _encoder) = (template, createContext, encoder);
 
     public string Render(object model)
     {
+        if (_compiledTemplate is null)
+        {
+             var parser = new FluidParser();
+            _compiledTemplate = parser.Parse(_template);
+        }
+        
         var context = _createContext(model);
         return _encoder is null
-            ? _template.Render(context)
-            : _template.Render(context, _encoder);
+            ? _compiledTemplate.Render(context)
+            : _compiledTemplate.Render(context, _encoder);
     }
 }

--- a/src/Didot.Core/TemplateEngines/FluidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/FluidRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+
+namespace Didot.Core.TemplateEngines;
+internal class FluidRenderer : IRenderer
+{
+    private readonly IFluidTemplate _template;
+    private readonly Func<object, TemplateContext> _createContext;
+    private readonly TextEncoder? _encoder;
+
+    public FluidRenderer(IFluidTemplate template, Func<object, TemplateContext> createContext, TextEncoder? encoder = null)
+        => (_template, _createContext, _encoder) = (template, createContext, encoder);
+
+    public string Render(object model)
+    {
+        var context = _createContext(model);
+        return _encoder is null
+            ? _template.Render(context)
+            : _template.Render(context, _encoder);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/FluidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/FluidRenderer.cs
@@ -15,6 +15,8 @@ internal class FluidRenderer : IRenderer
     private readonly Func<object, TemplateContext> _createContext;
     private readonly TextEncoder? _encoder;
 
+    private readonly object lockObj = new();
+
     public FluidRenderer(string template, Func<object, TemplateContext> createContext, TextEncoder? encoder = null)
         => (_template, _createContext, _encoder) = (template, createContext, encoder);
 
@@ -22,7 +24,7 @@ internal class FluidRenderer : IRenderer
     {
         if (_compiledTemplate is null)
         {
-            lock (this)
+            lock (lockObj)
             {
                 if (_compiledTemplate is null)
                 {

--- a/src/Didot.Core/TemplateEngines/FluidRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/FluidRenderer.cs
@@ -22,10 +22,18 @@ internal class FluidRenderer : IRenderer
     {
         if (_compiledTemplate is null)
         {
-             var parser = new FluidParser();
-            _compiledTemplate = parser.Parse(_template);
+            lock (this)
+            {
+                if (_compiledTemplate is null)
+                {
+                    var parser = new FluidParser();
+                    if (!parser.TryParse(_template, out var template, out var errors))
+                        throw new InvalidOperationException($"Failed to parse Fluid template: {string.Join(", ", errors)}");
+                    _compiledTemplate = template;
+                }
+            }
         }
-        
+
         var context = _createContext(model);
         return _encoder is null
             ? _compiledTemplate.Render(context)

--- a/src/Didot.Core/TemplateEngines/FluidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/FluidWrapper.cs
@@ -14,7 +14,7 @@ namespace Didot.Core.TemplateEngines;
 public class FluidWrapper : BaseTemplateEngine
 {
     private static readonly FluidParser Parser = new();
-    
+
     public FluidWrapper()
         : base()
     { }
@@ -32,7 +32,27 @@ public class FluidWrapper : BaseTemplateEngine
     public override string Render(string source, object model)
     {
         var template = Parser.Parse(source);
+        var context = CreateContext(model);
 
+        return Configuration.HtmlEncode
+            ? template.Render(context, HtmlEncoder.Default)
+            : template.Render(context);
+    }
+
+    public override string Render(Stream stream, object model)
+    {
+        using var reader = new StreamReader(stream);
+        var template = reader.ReadToEnd();
+        return Render(template, model);
+    }
+
+    public override IRenderer Prepare(string template)
+    {
+        return new FluidRenderer(Parser.Parse(template), (model) => CreateContext(model), Configuration.HtmlEncode ? HtmlEncoder.Default : null);
+    }
+
+    protected virtual TemplateContext CreateContext(object model)
+    {
         if (Configuration.WrapAsModel)
         {
             var isAlreadyWrapped = model.GetType().GetProperty("model") != null;
@@ -62,18 +82,7 @@ public class FluidWrapper : BaseTemplateEngine
                 return new StringValue(function(input.ToObjectValue()));
             });
         }
-
-        if (Configuration.HtmlEncode)
-            return template.Render(context, HtmlEncoder.Default);
-        else
-            return template.Render(context);
-    }
-
-    public override string Render(Stream stream, object model)
-    {
-        using var reader = new StreamReader(stream);
-        var template = reader.ReadToEnd();
-        return Render(template, model);
+        return context;
     }
 }
 

--- a/src/Didot.Core/TemplateEngines/FluidWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/FluidWrapper.cs
@@ -6,9 +6,6 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
-using SmartFormat.Core.Extensions;
 
 namespace Didot.Core.TemplateEngines;
 public class FluidWrapper : BaseTemplateEngine
@@ -48,7 +45,7 @@ public class FluidWrapper : BaseTemplateEngine
 
     public override IRenderer Prepare(string template)
     {
-        return new FluidRenderer(Parser.Parse(template), (model) => CreateContext(model), Configuration.HtmlEncode ? HtmlEncoder.Default : null);
+        return new FluidRenderer(template, (model) => CreateContext(model), Configuration.HtmlEncode ? HtmlEncoder.Default : null);
     }
 
     protected virtual TemplateContext CreateContext(object model)

--- a/src/Didot.Core/TemplateEngines/HandlebarsRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/HandlebarsRenderer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HandlebarsDotNet;
+
+namespace Didot.Core.TemplateEngines;
+internal class HandlebarsRenderer : IRenderer
+{
+    private readonly string _template;
+    private readonly Func<IHandlebars> _createContext;
+    private HandlebarsTemplate<object, object>? _compiledTemplate;
+
+    public HandlebarsRenderer(string template, Func<IHandlebars> createContext)
+        => (_template, _createContext) = (template, createContext);
+
+    public string Render(object model)
+    {
+        _compiledTemplate ??= _createContext().Compile(_template);
+        return _compiledTemplate(model);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/HandlebarsWrapper.cs
@@ -58,6 +58,11 @@ public class HandlebarsWrapper : BaseTemplateEngine
         return writer.ToString();
     }
 
+    public override IRenderer Prepare(string template)
+    {
+        return new HandlebarsRenderer(template, CreateContext);
+    }
+
     private IHandlebars CreateContext()
     {
         var config = new HandlebarsConfiguration { NoEscape = !Configuration.HtmlEncode };

--- a/src/Didot.Core/TemplateEngines/MorestachioRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/MorestachioRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HandlebarsDotNet;
+using Morestachio;
+using Morestachio.Rendering;
+
+namespace Didot.Core.TemplateEngines;
+internal class MorestachioRenderer : IRenderer
+{
+    private readonly string _template;
+    private Morestachio.Rendering.IRenderer? _renderer;
+
+    private readonly Func<string, IParserOptionsBuilder> _createContext;
+
+    public MorestachioRenderer(string template, Func<string, IParserOptionsBuilder> createContext)
+        => (_template, _createContext) = (template, createContext);
+
+    public string Render(object model)
+    {
+        _renderer ??= _createContext(_template).BuildAndParse().CreateRenderer();
+        return _renderer.RenderAndStringify(model);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/ScribanRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/ScribanRenderer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Scriban;
+
+namespace Didot.Core.TemplateEngines;
+internal class ScribanRenderer : IRenderer
+{
+    private readonly Template _compiledTemplate;
+    private readonly Func<object, TemplateContext> _createContext;
+
+    public ScribanRenderer(Template compiledTemplate, Func<object, TemplateContext> createContext)
+        => (_compiledTemplate, _createContext) = (compiledTemplate, createContext);
+
+    public string Render(object model)
+    {
+        var context = _createContext(model);
+        return _compiledTemplate.Render(context);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/ScribanRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/ScribanRenderer.cs
@@ -8,14 +8,19 @@ using Scriban;
 namespace Didot.Core.TemplateEngines;
 internal class ScribanRenderer : IRenderer
 {
-    private readonly Template _compiledTemplate;
+    private readonly string _template;
+    private Template? _compiledTemplate;
     private readonly Func<object, TemplateContext> _createContext;
 
-    public ScribanRenderer(Template compiledTemplate, Func<object, TemplateContext> createContext)
-        => (_compiledTemplate, _createContext) = (compiledTemplate, createContext);
+    public ScribanRenderer(string template, Func<object, TemplateContext> createContext)
+        => (_template, _createContext) = (template, createContext);
 
     public string Render(object model)
     {
+        _compiledTemplate ??= Template.Parse(_template);
+        if (_compiledTemplate.HasErrors)
+            throw new InvalidOperationException($"Scriban template parse error: {string.Join(", ", _compiledTemplate.Messages)}");
+
         var context = _createContext(model);
         return _compiledTemplate.Render(context);
     }

--- a/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
@@ -34,8 +34,12 @@ public class ScribanWrapper : BaseTemplateEngine
             template = include + template;
         }
 
-        var templateInstance = Template.Parse(template);
-        return templateInstance.Render(context);
+        var parsed = Template.Parse(template);
+
+        if (parsed.HasErrors)
+            throw new InvalidOperationException($"Scriban template parse error: {string.Join(", ", parsed.Messages)}");
+
+        return parsed.Render(context);
     }
 
     public override string Render(Stream stream, object model)
@@ -47,7 +51,7 @@ public class ScribanWrapper : BaseTemplateEngine
 
     public override IRenderer Prepare(string template)
     {
-        return new ScribanRenderer(Template.Parse(template), CreateContext);
+        return new ScribanRenderer(template, CreateContext);
     }
 
     protected virtual TemplateContext CreateContext(object model)

--- a/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/ScribanWrapper.cs
@@ -23,21 +23,48 @@ public class ScribanWrapper : BaseTemplateEngine
 
     public override string Render(string template, object model)
     {
-        var scriptObject = new ScriptObject();
+        var context = CreateContext(model);
+
+        if (Functions.Count > 0)
+        {
+            var include = string.Empty;
+            foreach (var name in Functions.Keys)
+                include += $"{{{{ include '{name}' ~}}}}\r\n";
+
+            template = include + template;
+        }
+
+        var templateInstance = Template.Parse(template);
+        return templateInstance.Render(context);
+    }
+
+    public override string Render(Stream stream, object model)
+    {
+        using var reader = new StreamReader(stream);
+        var template = reader.ReadToEnd();
+        return Render(template, model);
+    }
+
+    public override IRenderer Prepare(string template)
+    {
+        return new ScribanRenderer(Template.Parse(template), CreateContext);
+    }
+
+    protected virtual TemplateContext CreateContext(object model)
+    {
+        var modelScriptObject = new ScriptObject();
         if (!Configuration.WrapAsModel && model is IDictionary<string, object?>)
         {
-            var modelScriptObject = new ScriptObject();
             foreach (var item in (IDictionary<string, object?>)model)
                 modelScriptObject[item.Key] = item.Value;
-            scriptObject.Import(modelScriptObject);
         }
         else
         {
             var extractedModel = model.GetType().GetProperty("model") is null ? new { model } : model;
-            var modelScriptObject = new ScriptObject();
             modelScriptObject.Import(extractedModel);
-            scriptObject.Import(modelScriptObject);
         }
+        var scriptObject = new ScriptObject();
+        scriptObject.Import(modelScriptObject);
 
         foreach (var (funcName, function) in Formatters)
             scriptObject.Import(funcName, (string value) => function(value));
@@ -52,30 +79,12 @@ public class ScribanWrapper : BaseTemplateEngine
         foreach (var (funcName, dict) in Mappings)
             scriptObject.Import(funcName, (string value) => map(dict, value));
 
-        if (Functions.Count > 0)
-        {
-            var include = string.Empty;
-            foreach (var name in Functions.Keys)
-                include += $"{{{{ include '{name}' ~}}}}\r\n";
-
-            template = include + template;
-        }
-
         var context = Configuration.HtmlEncode ? new HtmlEncodeTemplateContext() : new TemplateContext();
         var merged = Functions.Concat(Partials).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         var templateLoader = new InlineIncludeTemplateLoader(merged);
         context.TemplateLoader = templateLoader;
         context.PushGlobal(scriptObject);
-
-        var templateInstance = Template.Parse(template);
-        return templateInstance.Render(context);
-    }
-
-    public override string Render(Stream stream, object model)
-    {
-        using var reader = new StreamReader(stream);
-        var template = reader.ReadToEnd();
-        return Render(template, model);
+        return context;
     }
 
     private class HtmlEncodeTemplateContext : TemplateContext

--- a/src/Didot.Core/TemplateEngines/SmartFormatRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/SmartFormatRenderer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SmartFormat;
+
+namespace Didot.Core.TemplateEngines;
+internal class SmartFormatRenderer : IRenderer
+{
+    private readonly string _template;
+    private readonly Func<object, object> _createContext;
+
+    public SmartFormatRenderer(string template, Func<object, object> createContext)
+        => (_template, _createContext) = (template, createContext);
+
+    public string Render(object model)
+    {
+        var context = _createContext(model);
+        return Smart.Format(_template, context);
+    }
+}

--- a/src/Didot.Core/TemplateEngines/SmartFormatWrapper.cs
+++ b/src/Didot.Core/TemplateEngines/SmartFormatWrapper.cs
@@ -28,14 +28,8 @@ public class SmartFormatWrapper : BaseTemplateEngine
 
     public override string Render(string template, object model)
     {
-        if (Configuration.WrapAsModel)
-        {
-            var isAlreadyWrapped = model.GetType().GetProperty("model") != null;
-            if (!isAlreadyWrapped)
-                model = new { model };
-        }
-
-        return Smart.Format(template, model);
+        var context = CreateContext(model);
+        return Smart.Format(template, context);
     }
 
     public override string Render(Stream stream, object model)
@@ -43,5 +37,21 @@ public class SmartFormatWrapper : BaseTemplateEngine
         using var reader = new StreamReader(stream);
         var template = reader.ReadToEnd();
         return Render(template, model);
+    }
+
+    public override IRenderer Prepare(string template)
+    {
+        return new SmartFormatRenderer(template, CreateContext);
+    }
+
+    protected virtual object CreateContext(object model)
+    {
+        if (Configuration.WrapAsModel)
+        {
+            var isAlreadyWrapped = model.GetType().GetProperty("model") != null;
+            if (!isAlreadyWrapped)
+                model = new { model };
+        }
+        return model;
     }
 }

--- a/src/Didot.Core/TemplateEngines/StringTemplateRenderer.cs
+++ b/src/Didot.Core/TemplateEngines/StringTemplateRenderer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Antlr4.StringTemplate;
+using Antlr4.StringTemplate.Compiler;
+
+namespace Didot.Core.TemplateEngines;
+internal class StringTemplateRenderer : IRenderer
+{
+    private readonly string _template;
+    private CompiledTemplate? _compiledTemplate;
+
+    private readonly Func<TemplateGroup> _createContext;
+    private TemplateGroup? _context;
+
+    private readonly Func<Template, object, Template> _setModel;
+
+    public StringTemplateRenderer(string template, Func<TemplateGroup> createContext, Func<Template, object, Template> setModel)
+        => (_template, _createContext, _setModel) = (template, createContext, setModel);
+
+    public string Render(object model)
+    {
+        _context ??= _createContext();
+        _compiledTemplate ??= new Template(_context, _template).impl;
+
+        var instance = _context.CreateStringTemplate(_compiledTemplate);
+        instance = _setModel(instance, model);
+        return instance.Render();
+    }
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/BaseRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/BaseRendererTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public abstract class BaseRendererTests
+{
+    protected abstract ITemplateEngine GetEngine();
+
+    [Test]
+    public abstract void Render_SingleProperty_Successful();
+    protected void Render_SingleProperty_Successful(string template)
+    {
+        var engine = GetEngine();
+        var renderer = engine.Prepare(template);
+        
+        Assert.That(renderer.Render(new { model = new Dictionary<string, object> { { "Name", "World"} } })
+            , Is.EqualTo("Hello World"));
+        Assert.That(renderer.Render(new { model = new Dictionary<string, object> { { "Name", "Cédric" } } })
+            , Is.EqualTo("Hello Cédric"));
+    }
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/DotLiquidRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/DotLiquidRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class DotLiquidRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new DotLiquidWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {{model.Name}}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/FluidRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/FluidRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class FluidRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new FluidWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {{model.Name}}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/HandlebarsRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/HandlebarsRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class HandlebarsRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new HandlebarsWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {{model.Name}}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/MorestachioRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/MorestachioRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class MorestachioRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new MorestachioWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {{model.Name}}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/ScribanRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/ScribanRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class ScribanRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new ScribanWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {{model.Name}}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/SmartFormatRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/SmartFormatRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class SmartFormatRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new SmartFormatWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello {model.Name}");
+}

--- a/testing/Didot.Core.Testing/TemplateEngines/StringTemplateRendererTests.cs
+++ b/testing/Didot.Core.Testing/TemplateEngines/StringTemplateRendererTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing.TemplateEngines;
+public class StringTemplateRendererTests : BaseRendererTests
+{
+    protected override ITemplateEngine GetEngine()
+        => new StringTemplateWrapper();
+
+    [Test]
+    public override void Render_SingleProperty_Successful()
+        => Render_SingleProperty_Successful("Hello <model.Name>");
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified renderer interface for template engines, enabling high-performance, reusable template rendering across all supported engines.
  - Added a new method to prepare and cache renderers for repeated use, improving efficiency for batch or repeated rendering scenarios.
  - Expanded support for stream-based template rendering in multiple engines.

- **Documentation**
  - Added comprehensive documentation for the new renderer interface and its usage patterns, including caching behaviors across engines.

- **Tests**
  - Implemented a suite of tests for the new renderer functionality across all supported template engines to ensure consistent and correct rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->