### PR TITLE
chore: bump System.CommandLine from 2.0.0+beta.5 to 2.0.0

### DIFF
--- a/src/Didot.Cli/Didot.Cli.csproj
+++ b/src/Didot.Cli/Didot.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+    <PackageReference Include="System.CommandLine" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Didot.Cli/Program.cs
+++ b/src/Didot.Cli/Program.cs
@@ -45,6 +45,6 @@ public class Program
         logger.LogInformation($"Didot Command Line Interface: version {Assembly.GetExecutingAssembly().GetName().Version}");
 
         var renderCommand = host.Services.GetRequiredService<RootCommand>();
-        return await renderCommand.InvokeAsync(args);
+        return await renderCommand.Parse(args).InvokeAsync();
     }
 }

--- a/src/Didot.Cli/RenderOptions.cs
+++ b/src/Didot.Cli/RenderOptions.cs
@@ -11,87 +11,83 @@ using Didot.Core;
 namespace Didot.Cli;
 public class RenderOptions
 {
-    public Option<string> Template { get; } = new Option<string>(
-        new[] { "-t", "--template" },
-        description: "Path to the template file."
-    )
+    public Option<string> Template { get; } = new Option<string>("--template", ["-t"])
     {
-        IsRequired = true,
+        Description = "Path to the template file.",
+        Required = true,
         Arity = ArgumentArity.ExactlyOne
     };
 
-    public Option<string> Engine { get; } = new Option<string>(
-        new[] { "-e", "--engine" },
-        description: "The template engine to use or to enforce when rendering the template.",
-        parseArgument: result => result.Tokens.Any() ? result.Tokens[0].Value.Trim() : string.Empty
-    )
+    public Option<string> Engine { get; } = new Option<string>("--engine", ["-e"])
     {
+        CustomParser = result => result.Tokens.Any() ? result.Tokens[0].Value.Trim() : string.Empty,
+        Description = "The template engine to use or to enforce when rendering the template.",
         Arity = ArgumentArity.ZeroOrOne
     };
 
     public Option<Dictionary<string, string>> EngineExtensions { get; } = new Option<Dictionary<string, string>>(
-        new[] { "-x", "--engine-extension" },
-        description: "Associate a file's extension to a specific template engine.",
-        parseArgument: result => ParseKeyValuePairs(result, ':', ';', NormalizeExtension)
+        "--engine-extension",["-x"]
     )
     {
+        CustomParser = result => ParseKeyValuePairs(result, ':', ';', NormalizeExtension),
+        Description = "Associate a file's extension to a specific template engine.",
         Arity = ArgumentArity.ZeroOrMore,
         AllowMultipleArgumentsPerToken = false
     };
 
     public Option<Dictionary<string, string>> Sources { get; } = new Option<Dictionary<string, string>>(
-        new[] { "-s", "--source" },
-        description: "Path to the source file.",
-        parseArgument: result => ParseKeyValuePairs(result, ':', ';', null, true)
+        "--source", ["-s"]
     )
     {
+        Description = "Path to the source file.",
+        CustomParser = result => ParseKeyValuePairs(result, ':', ';', null, true),
         Arity = ArgumentArity.ZeroOrMore,
         AllowMultipleArgumentsPerToken = true
     };
 
     public Option<bool> StdIn { get; } = new Option<bool>(
-        new[] { "-i", "--stdin" },
-        description: "Indicates that the input will come from stdin."
+        "--stdin", ["-i"]
     )
     {
+        Description = "Indicates that the input will come from stdin.",
         Arity = ArgumentArity.ZeroOrOne
     };
 
     public Option<string> Parser { get; } = new Option<string>(
-        new[] { "-r", "--parser" },
-        description: "The parser to use when reading from StdIn or to enforce when reading from files.",
-        parseArgument: result => result.Tokens.Any() ? result.Tokens[0].Value.Trim() : string.Empty
+        "--parser", ["-r"]
     )
     {
+        CustomParser = result => result.Tokens.Any() ? result.Tokens[0].Value.Trim() : string.Empty,
+        Description = "The parser to use when reading from StdIn or to enforce when reading from files.",
         Arity = ArgumentArity.ZeroOrOne
     };
 
     public Option<Dictionary<string, string>> ParserExtensions { get; } = new Option<Dictionary<string, string>>(
-            new[] { "-X", "--parser-extension" },
-            description: "Associate a file's extension to a specific parser.",
-            parseArgument: result => ParseKeyValuePairs(result, ':', ';', NormalizeExtension)
+            "--parser-extension", ["-X"]
     )
     {
         Arity = ArgumentArity.ZeroOrMore,
-        AllowMultipleArgumentsPerToken = true
+        AllowMultipleArgumentsPerToken = true,
+        CustomParser = result => ParseKeyValuePairs(result, ':', ';', NormalizeExtension),
+        Description = "Associate a file's extension to a specific parser.",
     };
 
     public Option<Dictionary<string, string>> ParserParams { get; } = new Option<Dictionary<string, string>>(
-            new[] { "-P", "--parser-parameter" },
-            description: "Provide key-value parameters for parsers, such as configuration or dialect settings.",
-            parseArgument: result => ParseKeyValuePairs(result, ':', ';')
+            "--parser-parameter", ["-P"]
     )
     {
         Arity = ArgumentArity.ZeroOrMore,
-        AllowMultipleArgumentsPerToken = true
+        AllowMultipleArgumentsPerToken = true,
+        CustomParser = result => ParseKeyValuePairs(result, ':', ';'),
+        Description = "Provide key-value parameters for parsers, such as configuration or dialect settings.",
     };
 
     public Option<string> Output { get; } = new Option<string>(
-        new[] { "-o", "--output" },
-        description: "Path to the generated file."
+        "--output", ["-o"]
     )
     {
-        Arity = ArgumentArity.ZeroOrOne
+        Arity = ArgumentArity.ZeroOrOne,
+        Description = "Path to the generated file."
     };
 
     private static Dictionary<string, string> ParseKeyValuePairs(ArgumentResult result, char keyValueSeparator, char pairSeparator, Func<string, string>? normalizeKey = null, bool allowEmptyKey = false)
@@ -110,7 +106,7 @@ public class RenderOptions
                         dictionary[string.Empty] = keyValue[0].Trim();
                     else
                     {
-                        result.ErrorMessage = $"The key is missing for the key-value pair: {pair}. A key is required when multiple key-value pairs are provided.";
+                        result.AddError($"The key is missing for the key-value pair: {pair}. A key is required when multiple key-value pairs are provided.");
                         return dictionary;
                     }
                 }
@@ -121,7 +117,7 @@ public class RenderOptions
                 }
                 else
                 {
-                    result.ErrorMessage = $"Invalid key-value pair: {pair}";
+                    result.AddError($"Invalid key-value pair: {pair}");
                     return dictionary;
                 }
             }

--- a/testing/Didot.Cli.Testing/ProgramTests.cs
+++ b/testing/Didot.Cli.Testing/ProgramTests.cs
@@ -186,7 +186,7 @@ public class ProgramTests
         };
         var exitCode = await Program.Main(args);
         Assert.That(exitCode, Is.Not.EqualTo(0));
-        Assert.That(ReadErrorStream(), Does.StartWith("Option '-t' is required."));
+        Assert.That(ReadErrorStream(), Does.Contain("Option '--template' is required."));
     }
 
     [Test]

--- a/testing/Didot.Cli.Testing/RenderOptions/EngineExtensionTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/EngineExtensionTests.cs
@@ -14,13 +14,11 @@ public class EngineExtensionTests
     public void EngineExtension_Empty_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.GetValueForOption(options.EngineExtensions), Is.Empty);
+        Assert.That(result.GetValue(options.EngineExtensions), Is.Empty);
     }
 
     [Test]
@@ -30,14 +28,12 @@ public class EngineExtensionTests
     public void EngineExtension_One_Valid(string additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.EngineExtensions);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.EngineExtensions);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(1));
         Assert.That(value, Does.ContainKey(".liquid"));
@@ -51,14 +47,12 @@ public class EngineExtensionTests
     public void EngineExtension_Many_Valid(string additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.EngineExtensions);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.EngineExtensions);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(2));
         Assert.That(value, Does.ContainKey(".liquid"));

--- a/testing/Didot.Cli.Testing/RenderOptions/OutputTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/OutputTests.cs
@@ -16,28 +16,24 @@ public class OutputTests
     public void Output_Provided_Valid(params string[] optionArray)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
         args.AddRange(optionArray);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.Output), Is.EqualTo("file1.txt"));
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.Output), Is.EqualTo("file1.txt"));
     }
 
     [Test]
     public void Output_NotProvided_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template=file1.txt", "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.Output), Is.Null);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.Output), Is.Null);
     }
 }

--- a/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
@@ -14,13 +14,11 @@ public class ParserExtensionTests
     public void ParserExtension_Empty_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.GetValueForOption(options.ParserExtensions), Is.Empty);
+        Assert.That(result.GetValue(options.ParserExtensions), Is.Empty);
     }
 
     [Test]
@@ -30,14 +28,12 @@ public class ParserExtensionTests
     public void ParserExtension_One_Valid(string additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.ParserExtensions);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.ParserExtensions);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(1));
         Assert.That(value, Does.ContainKey(".txt"));
@@ -53,15 +49,13 @@ public class ParserExtensionTests
     public void ParserExtension_Many_Valid(params string[] additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
         args.AddRange(additionalArgs);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.ParserExtensions);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.ParserExtensions);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(2));
         Assert.That(value, Does.ContainKey(".txt"));

--- a/testing/Didot.Cli.Testing/RenderOptions/ParserParamsTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/ParserParamsTests.cs
@@ -14,13 +14,11 @@ public class ParserParamsTests
     public void ParserParams_Empty_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.GetValueForOption(options.ParserParams), Is.Empty);
+        Assert.That(result.GetValue(options.ParserParams), Is.Empty);
     }
 
     [Test]
@@ -30,14 +28,12 @@ public class ParserParamsTests
     public void ParserExtension_One_Valid(string additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=stdin", additionalArgs };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.ParserParams);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.ParserParams);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(1));
         Assert.That(value, Does.ContainKey("txt@delimiter"));
@@ -51,15 +47,13 @@ public class ParserParamsTests
     public void ParserExtension_Many_Valid(params string[] additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=csv" };
         args.AddRange(additionalArgs);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.ParserParams);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.ParserParams);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(2));
         Assert.That(value, Does.ContainKey("txt@delimiter"));

--- a/testing/Didot.Cli.Testing/RenderOptions/ParserTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/ParserTests.cs
@@ -17,27 +17,23 @@ public class ParserTests
     public void Parser_Provided_Valid(string option)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template=file1.txt", "--stdin", option };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.Parser), Is.EqualTo("json"));
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.Parser), Is.EqualTo("json"));
     }
 
     [Test]
     public void Parser_NotProvided_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template=file1.txt", "--source=file.txt" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.Parser), Is.Null);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.Parser), Is.Null);
     }
 }

--- a/testing/Didot.Cli.Testing/RenderOptions/SourceTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/SourceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
@@ -14,13 +15,11 @@ public class SourceTests
     public void Source_Empty_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template=file1.txt", "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.GetValueForOption(options.Sources), Is.Empty);
+        Assert.That(result.GetValue(options.Sources), Is.Empty);
     }
 
     [Test]
@@ -31,15 +30,13 @@ public class SourceTests
     public void Source_One_Valid(params string[] additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template", "file1.txt" };
         args.AddRange(additionalArgs);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.Sources);
+        Assert.That(result.Errors, Is.Empty);
+        var value = result.GetValue(options.Sources);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(1));
         Assert.That(value, Does.ContainKey(string.Empty));
@@ -56,15 +53,13 @@ public class SourceTests
     public void Source_Many_Valid(params string[] additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt" };
         args.AddRange(additionalArgs);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        var value = context.ParseResult.GetValueForOption(options.Sources);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        var value = result.GetValue(options.Sources);
         Assert.That(value, Is.Not.Null);
         Assert.That(value, Has.Count.EqualTo(2));
         Assert.That(value, Does.ContainKey("employees"));
@@ -78,15 +73,13 @@ public class SourceTests
     public void Source_ManyWithoutKeys_Invalid(params string[] additionalArgs)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
         args.AddRange(additionalArgs);
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Not.Null.And.Not.Empty);
-        Assert.That(context.ParseResult.Errors.Select(x => x.Message)
+        Assert.That(result.Errors, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Errors.Select(x => x.Message)
             , Does.Contain("The key is missing for the key-value pair: org.yaml. A key is required when multiple key-value pairs are provided."));
     }
 }

--- a/testing/Didot.Cli.Testing/RenderOptions/StdinTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/StdinTests.cs
@@ -18,28 +18,24 @@ public class StdInTests
     public void StdIn_Provided_Valid(string stdIn)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template", "file1.txt", "--parser", "json", stdIn };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.StdIn), Is.True);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.StdIn), Is.True);
     }
 
     [Test]
     public void StdIn_NotProvided_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template=file1.txt", "--source=file.json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.StdIn), Is.False);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.StdIn), Is.False);
     }
 
     [Test]
@@ -47,84 +43,72 @@ public class StdInTests
     public void StdIn_ProvidedExplicitelySet_Valid(bool value)
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template", "file1.txt", "--parser", "json", "--stdin", $"{value}" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
-        Assert.That(context.ParseResult.GetValueForOption(options.StdIn), Is.EqualTo(value));
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+        Assert.That(result.GetValue(options.StdIn), Is.EqualTo(value));
     }
 
     [Test]
     public void StdInSource_BothProvided_Error()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
-        var args = new List<string>() { "--template=file1.txt", "--stdin", "--source=file1.json"};
+        var args = new List<string>() { "--template=file1.txt", "--stdin", "--source=file1.json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Not.Null.And.Not.Empty);
-        Assert.That(context.ParseResult.Errors.Select(x => x.Message), Does.Contain("The --stdin option cannot be provided together with the --source option."));
+        Assert.That(result.Errors, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Errors.Select(x => x.Message), Does.Contain("The --stdin option cannot be provided together with the --source option."));
     }
 
     [Test]
     public void StdInSource_BothProvidedButStdInSetToFalse_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template", "file1.txt" };
         args.AddRange(new[] { "--stdin", "false" });
         args.AddRange(new[] { "--source", "file1.json" });
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
     }
 
     [Test]
     public void StdInParser_ParserNotProvided_Error()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
-        var args = new List<string>() { "--template=file1.txt", "--stdin"};
+        var args = new List<string>() { "--template=file1.txt", "--stdin" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Not.Null.And.Not.Empty);
-        Assert.That(context.ParseResult.Errors.Select(x => x.Message), Does.Contain("The --parser option is required when using --stdin to specify the input source."));
+        Assert.That(result.Errors, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Errors.Select(x => x.Message), Does.Contain("The --parser option is required when using --stdin to specify the input source."));
     }
 
     [Test]
     public void StdInParser_ParserNotProvidedButStdInSetToFalse_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template=file1.txt", "--stdin", "false", "--source=file.json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Null.Or.Empty);
+        Assert.That(result.Errors, Is.Null.Or.Empty);
     }
 
     [Test]
     public void StdInParserSource_ParserNotProvidedSourceProvided_Errors()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new List<string>() { "--template", "file1.txt" };
         args.AddRange(new[] { "--stdin" });
         args.AddRange(new[] { "--source", "file1.json" });
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Errors, Is.Not.Null.And.Not.Empty);
     }
 }

--- a/testing/Didot.Cli.Testing/RenderOptions/TemplateTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/TemplateTests.cs
@@ -14,27 +14,22 @@ public class TemplateTests
     public void Template_Provided_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--template", "file1.txt" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.GetValueForOption(options.Template), Is.EqualTo("file1.txt"));
+        Assert.That(result.GetValue(options.Template), Is.EqualTo("file1.txt"));
     }
 
     [Test]
     public void Template_Empty_Valid()
     {
         var options = new Cli.RenderOptions();
-        var parser = new Parser(new RenderCommand(options));
         var args = new[] { "--stdin", "--parser=json" };
 
-        var result = parser.Parse(args);
-        var context = new InvocationContext(result);
+        var result = new RenderCommand(options).Parse(args);
 
-        Assert.That(context.ParseResult.Errors, Is.Not.Null.And.Not.Empty);
-        Assert.That(context.ParseResult.Errors.Select(x => x.Message), Does.Contain("Option '-t' is required."));
-        Assert.That(context.ParseResult.GetValueForOption(options.Template), Is.Null);
+        Assert.That(result.Errors, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Errors.Select(x => x.Message), Does.Contain("Option '--template' is required."));
     }
 }

--- a/testing/Didot.Core.Testing/Didot.Core.Testing.csproj
+++ b/testing/Didot.Core.Testing/Didot.Core.Testing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command-line error messages and argument parsing validation for clearer user feedback.

* **Chores**
  * Upgraded System.CommandLine to stable 2.0.0 release for improved reliability.
  * Updated test infrastructure and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->