### PR TITLE
feat: baseline for extensions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot Instructions
+
+## Project Guidelines
+- User prefers exception-first API design in .Core for extension loading, with domain-specific exceptions as primary flow and optional TryX convenience methods for expected-absence discovery scenarios.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,30 @@ In this example:
 - Mandatory: no.
 - Example: `-o path/to/output` or `--output=path/to/output`
 
+### Extensions register command
+
+- Command: `didot extensions register <reference>`
+- Optional: `--name <friendly-name>`
+- Description: Registers an extension in Didot's extension registry.
+
+`<reference>` can be an id/name/assembly name, a `.dll` file path, or a directory path containing one extension assembly.
+
+Examples:
+
+```bash
+didot extensions register Didot.Expressif
+didot extensions register ./Didot.Expressif.dll
+didot extensions register ./extensions/Didot.Expressif --name Expressif
+```
+
+When the reference is not a path, Didot probes in this order:
+1. current directory
+2. current directory `/extensions`
+3. Didot installation directory `/extensions`
+4. user-level `~/.didot/extensions`
+
+If more than one candidate matches, registration fails and asks for an explicit path.
+
 #### Example:
 
 ##### With a source file:

--- a/README.md
+++ b/README.md
@@ -340,6 +340,29 @@ When the reference is not a path, Didot probes in this order:
 
 If more than one candidate matches, registration fails and asks for an explicit path.
 
+### Extension loading at runtime
+
+When rendering, Didot reads registered extensions from the static installation registry file:
+
+- `didot.extensions.registry.json` (in the Didot installation directory)
+
+For each enabled entry, Didot:
+
+1. loads the registered assembly,
+2. searches for exactly one class marked with `DidotExtensionAttribute`,
+3. requires that class to implement `IPipelineExtensionHook`,
+4. creates it using a public parameterless constructor,
+5. adds the instance as a render pipeline hook.
+
+If loading fails, Didot reports a controlled diagnostic with an error code, for example:
+
+- `RegistrationFileInvalid`
+- `ExtensionSourceNotFound`
+- `AssemblyLoadFailed`
+- `ExtensionTypeNotFound`
+- `ExtensionTypeAmbiguous`
+- `ExtensionInstantiationFailed`
+
 #### Example:
 
 ##### With a source file:

--- a/docs/_data/navigation_docs.yml
+++ b/docs/_data/navigation_docs.yml
@@ -37,3 +37,9 @@
 - title: Parsers
   docs:
   - csv-parser
+  
+- title: Extensions
+  docs:
+  - extensions-concept
+  - extensions-register
+  - extensions-develop

--- a/docs/_docs/cli-options.md
+++ b/docs/_docs/cli-options.md
@@ -130,3 +130,22 @@ Example: `-t path/to/template` or `--template=path/to/template`
 - Accept: single value.
 - Mandatory: no.
 - Example: `-o path/to/output` or `--output=path/to/output`
+
+### Extensions register command
+
+- Command: `didot extensions register <reference>`
+- Optional: `--name <friendly-name>`
+- Description: Registers an extension in Didot's extension registry.
+
+`<reference>` is a neutral reference and can be:
+- an assembly path: `./Didot.Expressif.dll`
+- a directory path containing one extension assembly: `./extensions/Didot.Expressif/`
+- a non-path identifier resolved by lookup (id, friendly name, or assembly name): `Didot.Expressif`
+
+Lookup order for non-path references:
+1. current directory
+2. current directory `/extensions`
+3. Didot installation directory `/extensions`
+4. user-level `~/.didot/extensions`
+
+If multiple candidates match, registration fails and requires an explicit path.

--- a/docs/_docs/extensions-concept.md
+++ b/docs/_docs/extensions-concept.md
@@ -1,0 +1,34 @@
+---
+title: Extension concept
+tags: [extensions, cli-usage]
+---
+## Overview
+
+An extension lets you customize Didot's rendering pipeline by injecting your own code.
+
+At runtime, Didot loads registered extension assemblies and executes hooks on the model **before** template rendering.
+
+## What an extension does
+
+A Didot extension implements `IPipelineExtensionHook`:
+
+- Input: the current model object.
+- Output: the transformed model object.
+
+This allows scenarios such as:
+
+- adding computed fields,
+- normalizing or reshaping model data,
+- enforcing domain-specific transformations before rendering.
+
+## Runtime behavior
+
+During `didot` execution:
+
+1. Didot reads the extension registry file.
+2. Enabled extension sources are resolved to assembly paths.
+3. Each assembly is loaded.
+4. A compatible hook type (`IPipelineExtensionHook` + `DidotExtensionAttribute`) is instantiated.
+5. Hooks are executed in registration order.
+
+If no registry file is present, Didot runs normally without extension hooks.

--- a/docs/_docs/extensions-develop.md
+++ b/docs/_docs/extensions-develop.md
@@ -1,0 +1,56 @@
+---
+title: Develop an extension
+tags: [extensions, development]
+---
+## 1. Create a .NET class library
+
+Create a class library targeting a compatible .NET runtime and reference `Didot.Core`.
+
+## 2. Add extension metadata
+
+Add assembly-level metadata (required for registration metadata discovery):
+
+```csharp
+using Didot.Core;
+
+[assembly: DidotExtension("my.company.transform", "My Transform Extension")]
+```
+
+## 3. Implement a pipeline hook
+
+Create a class that:
+
+- implements `IPipelineExtensionHook`,
+- is decorated with `DidotExtensionAttribute`,
+- has a public parameterless constructor.
+
+```csharp
+using Didot.Core;
+
+[DidotExtension("my.company.transform", "My Transform Hook")]
+public sealed class MyTransformHook : IPipelineExtensionHook
+{
+    public object Apply(object model)
+    {
+        // transform and return model
+        return model;
+    }
+}
+```
+
+## 4. Build and register
+
+Build the project and register the produced DLL:
+
+```bash
+didot extensions register ./bin/Debug/net8.0/MyExtension.dll
+```
+
+Then run Didot as usual (`didot -t ... -s ...`).
+
+## 5. Design guidance
+
+- Keep `Apply` deterministic and side-effect free when possible.
+- Always return a non-null model.
+- Throw meaningful exceptions for invalid model states.
+- Keep hook logic focused on model transformation (not template rendering).

--- a/docs/_docs/extensions-register.md
+++ b/docs/_docs/extensions-register.md
@@ -1,0 +1,57 @@
+---
+title: Register an extension
+tags: [extensions, cli-usage]
+---
+## Command
+
+Use the extension registration command:
+
+```bash
+didot extensions register <reference>
+```
+
+Optional friendly name override:
+
+```bash
+didot extensions register <reference> --name "My Extension"
+```
+
+## Supported references
+
+`<reference>` can be:
+
+- a DLL path (absolute or relative),
+- a directory containing exactly one DLL,
+- a non-path identifier (extension id, extension name, or assembly name).
+
+Examples:
+
+```bash
+didot extensions register ./Didot.Expressif.dll
+didot extensions register ./extensions/Didot.Expressif/
+didot extensions register Didot.Expressif
+```
+
+## Lookup order for non-path references
+
+When `<reference>` is not a path, Didot searches in this order:
+
+1. current directory
+2. current directory `extensions/`
+3. Didot installation directory `extensions/`
+4. user directory `~/.didot/extensions/`
+
+If multiple matches are found, registration fails and you must provide an explicit path.
+
+## Registry behavior
+
+On success, Didot stores the extension in `didot.extensions.registry.json` with:
+
+- id,
+- name,
+- assembly path,
+- enabled flag,
+- version,
+- registration timestamp.
+
+Didot rejects duplicate registrations by id or assembly path.

--- a/docs/_docs/extensions-register.md
+++ b/docs/_docs/extensions-register.md
@@ -18,7 +18,7 @@ didot extensions register <reference> --name "My Extension"
 
 ## Supported references
 
-`<reference>` can be:
+Supported `<reference>` values are:
 
 - a DLL path (absolute or relative),
 - a directory containing exactly one DLL,

--- a/src/Didot.Cli/CliException.cs
+++ b/src/Didot.Cli/CliException.cs
@@ -1,0 +1,10 @@
+namespace Didot.Cli;
+
+public abstract class CliException : Exception
+{
+    public CliExitCode ExitCode { get; }
+
+    protected CliException(CliExitCode exitCode, string message, Exception? innerException = null)
+        : base(message, innerException)
+        => ExitCode = exitCode;
+}

--- a/src/Didot.Cli/CliExitCode.cs
+++ b/src/Didot.Cli/CliExitCode.cs
@@ -1,0 +1,10 @@
+namespace Didot.Cli;
+
+public enum CliExitCode
+{
+    Success = 0,
+    InvalidInput = 2,
+    NotFound = 3,
+    LoadFailure = 4,
+    InternalError = 99,
+}

--- a/src/Didot.Cli/CliRootCommand.cs
+++ b/src/Didot.Cli/CliRootCommand.cs
@@ -5,10 +5,14 @@ namespace Didot.Cli;
 
 public class CliRootCommand : RootCommand
 {
-    public CliRootCommand(RenderOptions renderOptions, ExtensionsCommand extensionsCommand, ILogger<RenderCommand>? logger = null)
+    public CliRootCommand(
+        RenderOptions renderOptions,
+        ExtensionsCommand extensionsCommand,
+        RenderCommandHandler? renderCommandHandler = null,
+        ILogger<RenderCommand>? logger = null)
         : base("Didot Command Line Interface")
     {
-        RenderCommand.Configure(this, renderOptions, logger);
+        RenderCommand.Configure(this, renderOptions, logger, renderCommandHandler);
         Subcommands.Add(extensionsCommand);
     }
 }

--- a/src/Didot.Cli/CliRootCommand.cs
+++ b/src/Didot.Cli/CliRootCommand.cs
@@ -1,0 +1,14 @@
+using System.CommandLine;
+using Microsoft.Extensions.Logging;
+
+namespace Didot.Cli;
+
+public class CliRootCommand : RootCommand
+{
+    public CliRootCommand(RenderOptions renderOptions, ExtensionsCommand extensionsCommand, ILogger<RenderCommand>? logger = null)
+        : base("Didot Command Line Interface")
+    {
+        RenderCommand.Configure(this, renderOptions, logger);
+        Subcommands.Add(extensionsCommand);
+    }
+}

--- a/src/Didot.Cli/ExtensionAssemblyLoader.cs
+++ b/src/Didot.Cli/ExtensionAssemblyLoader.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public class ExtensionAssemblyLoader
+{
+    public virtual LoadedExtension Load(string extensionSource, string? extensionId = null)
+    {
+        if (string.IsNullOrWhiteSpace(extensionSource))
+            throw new ExtensionSourceNotFoundException(sourcePath: extensionSource);
+
+        var fullPath = Path.GetFullPath(extensionSource.Trim());
+        if (!File.Exists(fullPath))
+            throw new ExtensionSourceNotFoundException(sourcePath: fullPath);
+
+        var assembly = LoadAssembly(fullPath);
+        var extensionType = FindExtensionType(assembly, fullPath, extensionId);
+        var instance = Instantiate(extensionType, fullPath);
+
+        return new LoadedExtension(fullPath, extensionType.FullName ?? extensionType.Name, instance);
+    }
+
+    protected virtual Assembly LoadAssembly(string assemblyPath)
+    {
+        try
+        {
+            return Assembly.LoadFrom(assemblyPath);
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw new AssemblyLoadFailedException(assemblyPath, ex);
+        }
+        catch (FileLoadException ex)
+        {
+            throw new AssemblyLoadFailedException(assemblyPath, ex);
+        }
+        catch (BadImageFormatException ex)
+        {
+            throw new AssemblyLoadFailedException(assemblyPath, ex);
+        }
+        catch (Exception ex)
+        {
+            throw new AssemblyLoadFailedException(assemblyPath, ex);
+        }
+    }
+
+    protected virtual Type FindExtensionType(Assembly assembly, string assemblyPath, string? extensionId)
+    {
+        var candidates = GetLoadableTypes(assembly)
+            .Where(x => x is { IsClass: true, IsAbstract: false })
+            .Select(x => new
+            {
+                Type = x,
+                Attribute = x.GetCustomAttribute<DidotExtensionAttribute>(),
+            })
+            .Where(x => x.Attribute is not null)
+            .Where(x => typeof(IPipelineExtensionHook).IsAssignableFrom(x.Type))
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(extensionId))
+            candidates = candidates
+                .Where(x => x.Attribute!.Id.Equals(extensionId, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+        if (candidates.Count == 0)
+            throw new ExtensionTypeNotFoundException(sourcePath: assemblyPath);
+
+        if (candidates.Count > 1)
+            throw new ExtensionTypeAmbiguousException(sourcePath: assemblyPath);
+
+        return candidates[0].Type;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(x => x is not null)!;
+        }
+    }
+
+    protected virtual IPipelineExtensionHook Instantiate(Type extensionType, string assemblyPath)
+    {
+        try
+        {
+            if (extensionType.GetConstructor(Type.EmptyTypes) is null)
+                throw new ExtensionInstantiationFailedException(sourcePath: assemblyPath);
+
+            var instance = Activator.CreateInstance(extensionType) as IPipelineExtensionHook;
+            if (instance is null)
+                throw new ExtensionInstantiationFailedException(sourcePath: assemblyPath);
+
+            return instance;
+        }
+        catch (ExtensionException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ExtensionInstantiationFailedException(assemblyPath, ex);
+        }
+    }
+}

--- a/src/Didot.Cli/ExtensionAssemblyLoader.cs
+++ b/src/Didot.Cli/ExtensionAssemblyLoader.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Loader;
 using Didot.Core;
 
 namespace Didot.Cli;
@@ -25,7 +26,7 @@ public class ExtensionAssemblyLoader
     {
         try
         {
-            return Assembly.LoadFrom(assemblyPath);
+            return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
         }
         catch (FileNotFoundException ex)
         {

--- a/src/Didot.Cli/ExtensionCliException.cs
+++ b/src/Didot.Cli/ExtensionCliException.cs
@@ -1,0 +1,21 @@
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public sealed class ExtensionCliException : CliException
+{
+    public Type ErrorType { get; }
+    public string? SourcePath { get; }
+
+    public ExtensionCliException(
+        Type errorType,
+        CliExitCode exitCode,
+        string message,
+        string? sourcePath = null,
+        Exception? innerException = null)
+        : base(exitCode, message, innerException)
+    {
+        ErrorType = errorType;
+        SourcePath = sourcePath;
+    }
+}

--- a/src/Didot.Cli/ExtensionExceptionExtensions.cs
+++ b/src/Didot.Cli/ExtensionExceptionExtensions.cs
@@ -1,0 +1,14 @@
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public static class ExtensionExceptionExtensions
+{
+    public static ExtensionCliException ToCliException(this ExtensionException error)
+        => new(
+            error.GetType(),
+            error.ToCliExitCode(),
+            $"[{error.GetType().Name}] {error.Message}",
+            error.SourcePath,
+            error.InnerException);
+}

--- a/src/Didot.Cli/ExtensionLoadErrorCodeExtensions.cs
+++ b/src/Didot.Cli/ExtensionLoadErrorCodeExtensions.cs
@@ -1,0 +1,19 @@
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public static class ExtensionLoadExceptionExtensions
+{
+    public static CliExitCode ToCliExitCode(this ExtensionException exception)
+        => exception switch
+        {
+            RegistrationFileNotFoundException => CliExitCode.NotFound,
+            RegistrationFileInvalidException => CliExitCode.LoadFailure,
+            ExtensionSourceNotFoundException => CliExitCode.NotFound,
+            AssemblyLoadFailedException => CliExitCode.LoadFailure,
+            ExtensionTypeNotFoundException => CliExitCode.LoadFailure,
+            ExtensionTypeAmbiguousException => CliExitCode.LoadFailure,
+            ExtensionInstantiationFailedException => CliExitCode.LoadFailure,
+            _ => CliExitCode.InternalError,
+        };
+}

--- a/src/Didot.Cli/ExtensionMetadata.cs
+++ b/src/Didot.Cli/ExtensionMetadata.cs
@@ -1,0 +1,9 @@
+namespace Didot.Cli;
+
+public sealed record ExtensionMetadata(
+    string Id,
+    string Name,
+    string Version,
+    string AssemblyPath,
+    string AssemblyName
+);

--- a/src/Didot.Cli/ExtensionMetadataReader.cs
+++ b/src/Didot.Cli/ExtensionMetadataReader.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public class ExtensionMetadataReader
+{
+    public virtual bool TryRead(string assemblyPath, out ExtensionMetadata? metadata, out string? error)
+    {
+        metadata = null;
+        error = null;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(assemblyPath);
+            var assembly = Assembly.LoadFrom(fullPath);
+            var attribute = assembly.GetCustomAttribute<DidotExtensionAttribute>();
+            if (attribute is null)
+            {
+                error = $"Missing assembly attribute {nameof(DidotExtensionAttribute)}.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(attribute.Id))
+            {
+                error = "Extension metadata id is required.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(attribute.Name))
+            {
+                error = "Extension metadata name is required.";
+                return false;
+            }
+
+            var assemblyName = assembly.GetName().Name ?? Path.GetFileNameWithoutExtension(fullPath);
+            var version = string.IsNullOrWhiteSpace(attribute.Version)
+                ? assembly.GetName().Version?.ToString() ?? "0.0.0.0"
+                : attribute.Version.Trim();
+
+            metadata = new ExtensionMetadata(
+                attribute.Id.Trim(),
+                attribute.Name.Trim(),
+                version,
+                fullPath,
+                assemblyName
+            );
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    public virtual ExtensionMetadata Read(string assemblyPath)
+    {
+        if (!TryRead(assemblyPath, out var metadata, out var error) || metadata is null)
+            throw new InvalidOperationException($"Unable to read extension metadata from '{assemblyPath}'. {error}");
+
+        return metadata;
+    }
+}

--- a/src/Didot.Cli/ExtensionMetadataReader.cs
+++ b/src/Didot.Cli/ExtensionMetadataReader.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Loader;
 using Didot.Core;
 
 namespace Didot.Cli;
@@ -13,7 +14,7 @@ public class ExtensionMetadataReader
         try
         {
             var fullPath = Path.GetFullPath(assemblyPath);
-            var assembly = Assembly.LoadFrom(fullPath);
+            var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(fullPath);
             var attribute = assembly.GetCustomAttribute<DidotExtensionAttribute>();
             if (attribute is null)
             {

--- a/src/Didot.Cli/ExtensionReferenceResolver.cs
+++ b/src/Didot.Cli/ExtensionReferenceResolver.cs
@@ -31,7 +31,7 @@ public class ExtensionReferenceResolver
         => Path.IsPathRooted(reference)
             || reference.Contains(Path.DirectorySeparatorChar)
             || reference.Contains(Path.AltDirectorySeparatorChar)
-            || reference.StartsWith(".");
+            || reference.StartsWith('.');
 
     private static string ResolveFromDirectory(string directory)
     {

--- a/src/Didot.Cli/ExtensionReferenceResolver.cs
+++ b/src/Didot.Cli/ExtensionReferenceResolver.cs
@@ -161,6 +161,12 @@ public class ExtensionReferenceResolver
         if (!Directory.Exists(directory))
             return [];
 
-        return Directory.GetFiles(directory, "*.dll", searchOption);
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = searchOption == SearchOption.AllDirectories,
+            IgnoreInaccessible = true,
+        };
+
+        return Directory.EnumerateFiles(directory, "*.dll", options);
     }
 }

--- a/src/Didot.Cli/ExtensionReferenceResolver.cs
+++ b/src/Didot.Cli/ExtensionReferenceResolver.cs
@@ -82,7 +82,7 @@ public class ExtensionReferenceResolver
                 + string.Join(Environment.NewLine, candidates.Select(x => $"- {x}"))
                 + Environment.NewLine + Environment.NewLine
                 + "Register one explicitly:" + Environment.NewLine
-                + $"didot extensions register {candidates[0]}"
+                + $"didot extensions register \"{candidates[0]}\""
             );
         }
 

--- a/src/Didot.Cli/ExtensionReferenceResolver.cs
+++ b/src/Didot.Cli/ExtensionReferenceResolver.cs
@@ -1,0 +1,166 @@
+using System.Reflection;
+
+namespace Didot.Cli;
+
+public class ExtensionReferenceResolver
+{
+    private ExtensionMetadataReader MetadataReader { get; }
+    private string InstallationDirectory { get; }
+
+    public ExtensionReferenceResolver(ExtensionMetadataReader metadataReader)
+        : this(metadataReader, AppContext.BaseDirectory)
+    { }
+
+    public ExtensionReferenceResolver(ExtensionMetadataReader metadataReader, string installationDirectory)
+    {
+        MetadataReader = metadataReader;
+        InstallationDirectory = Path.GetFullPath(installationDirectory);
+    }
+
+    public virtual string ResolveAssemblyPath(string reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference))
+            throw new InvalidOperationException("The extension reference cannot be empty.");
+
+        return IsExplicitPath(reference)
+            ? ResolveFromExplicitPath(reference)
+            : ResolveFromLookup(reference.Trim());
+    }
+
+    private static bool IsExplicitPath(string reference)
+        => Path.IsPathRooted(reference)
+            || reference.Contains(Path.DirectorySeparatorChar)
+            || reference.Contains(Path.AltDirectorySeparatorChar)
+            || reference.StartsWith(".");
+
+    private static string ResolveFromDirectory(string directory)
+    {
+        var assemblies = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFullPath)
+            .ToList();
+
+        if (assemblies.Count == 0)
+            throw new InvalidOperationException($"No extension assembly (*.dll) found in '{directory}'.");
+
+        if (assemblies.Count > 1)
+            throw new InvalidOperationException(
+                $"Multiple extension assemblies were found in '{directory}'.{Environment.NewLine}"
+                + string.Join(Environment.NewLine, assemblies.Select(x => $"- {x}"))
+            );
+
+        return assemblies[0];
+    }
+
+    private string ResolveFromExplicitPath(string reference)
+    {
+        var fullPath = Path.GetFullPath(reference.Trim());
+        if (File.Exists(fullPath))
+        {
+            if (!fullPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Only .dll files can be registered as extensions.");
+            return fullPath;
+        }
+
+        if (Directory.Exists(fullPath))
+            return ResolveFromDirectory(fullPath);
+
+        throw new InvalidOperationException($"No file or directory found for reference '{reference}'.");
+    }
+
+    private string ResolveFromLookup(string reference)
+    {
+        var candidates = FindCandidates(reference).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (candidates.Count == 0)
+            throw new InvalidOperationException($"No extension matches '{reference}'.");
+
+        if (candidates.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"Multiple extensions match '{reference}'.{Environment.NewLine}{Environment.NewLine}"
+                + "Found:" + Environment.NewLine
+                + string.Join(Environment.NewLine, candidates.Select(x => $"- {x}"))
+                + Environment.NewLine + Environment.NewLine
+                + "Register one explicitly:" + Environment.NewLine
+                + $"didot extensions register {candidates[0]}"
+            );
+        }
+
+        return candidates[0];
+    }
+
+    private IEnumerable<string> FindCandidates(string reference)
+    {
+        var normalizedReference = reference.Trim();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var assemblyPath in ProbeAssemblyPaths())
+        {
+            var fullPath = Path.GetFullPath(assemblyPath);
+            if (!seen.Add(fullPath))
+                continue;
+
+            var assemblyName = GetAssemblyName(fullPath);
+            if (assemblyName is null)
+                continue;
+
+            if (assemblyName.Equals(normalizedReference, StringComparison.OrdinalIgnoreCase))
+            {
+                yield return fullPath;
+                continue;
+            }
+
+            if (!MetadataReader.TryRead(fullPath, out var metadata, out _ ) || metadata is null)
+                continue;
+
+            if (metadata.Id.Equals(normalizedReference, StringComparison.OrdinalIgnoreCase)
+                || metadata.Name.Equals(normalizedReference, StringComparison.OrdinalIgnoreCase))
+            {
+                yield return fullPath;
+            }
+        }
+    }
+
+    private static string? GetAssemblyName(string assemblyPath)
+    {
+        try
+        {
+            return AssemblyName.GetAssemblyName(assemblyPath).Name;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private IEnumerable<string> ProbeAssemblyPaths()
+    {
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var currentExtensions = Path.Combine(currentDirectory, "extensions");
+        var installationExtensions = Path.Combine(InstallationDirectory, "extensions");
+        var userExtensions = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".didot",
+            "extensions");
+
+        foreach (var path in EnumerateDlls(currentDirectory, SearchOption.TopDirectoryOnly))
+            yield return path;
+
+        foreach (var path in EnumerateDlls(currentExtensions, SearchOption.AllDirectories))
+            yield return path;
+
+        foreach (var path in EnumerateDlls(installationExtensions, SearchOption.AllDirectories))
+            yield return path;
+
+        foreach (var path in EnumerateDlls(userExtensions, SearchOption.AllDirectories))
+            yield return path;
+    }
+
+    private static IEnumerable<string> EnumerateDlls(string directory, SearchOption searchOption)
+    {
+        if (!Directory.Exists(directory))
+            return [];
+
+        return Directory.GetFiles(directory, "*.dll", searchOption);
+    }
+}

--- a/src/Didot.Cli/ExtensionRegistryEntry.cs
+++ b/src/Didot.Cli/ExtensionRegistryEntry.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Didot.Cli;
+
+public sealed class ExtensionRegistryEntry
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("assembly")]
+    public required string Assembly { get; init; }
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; init; } = true;
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("registeredAt")]
+    public DateTimeOffset RegisteredAt { get; init; }
+}

--- a/src/Didot.Cli/ExtensionsCommand.cs
+++ b/src/Didot.Cli/ExtensionsCommand.cs
@@ -1,0 +1,12 @@
+using System.CommandLine;
+
+namespace Didot.Cli;
+
+public class ExtensionsCommand : Command
+{
+    public ExtensionsCommand(RegisterExtensionCommand registerExtensionCommand)
+        : base("extensions", "Manage Didot extensions.")
+    {
+        Subcommands.Add(registerExtensionCommand);
+    }
+}

--- a/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
+++ b/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
@@ -5,6 +5,7 @@ namespace Didot.Cli;
 public class InstallationExtensionRegistryRepository
 {
     public const string RegistryFileName = "didot.extensions.registry.json";
+    private readonly object _lock = new();
 
     public string RegistryPath { get; }
 
@@ -24,21 +25,31 @@ public class InstallationExtensionRegistryRepository
         if (string.IsNullOrWhiteSpace(json))
             return [];
 
-        return JsonSerializer.Deserialize<List<ExtensionRegistryEntry>>(json) ?? [];
+        try
+        {
+            return JsonSerializer.Deserialize<List<ExtensionRegistryEntry>>(json) ?? [];
+        }
+        catch (JsonException ex)
+        {
+            throw new Core.RegistrationFileInvalidException(RegistryPath, ex);
+        }
     }
 
     public virtual void Register(ExtensionRegistryEntry entry)
     {
-        var entries = ReadAll().ToList();
+        lock (_lock)
+        {
+            var entries = ReadAll().ToList();
 
-        if (entries.Any(x => x.Id.Equals(entry.Id, StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"An extension with id '{entry.Id}' is already registered.");
+            if (entries.Any(x => x.Id.Equals(entry.Id, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"An extension with id '{entry.Id}' is already registered.");
 
-        if (entries.Any(x => Path.GetFullPath(x.Assembly).Equals(Path.GetFullPath(entry.Assembly), StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"The assembly '{entry.Assembly}' is already registered.");
+            if (entries.Any(x => Path.GetFullPath(x.Assembly).Equals(Path.GetFullPath(entry.Assembly), StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"The assembly '{entry.Assembly}' is already registered.");
 
-        entries.Add(entry);
-        Save(entries);
+            entries.Add(entry);
+            Save(entries);
+        }
     }
 
     private void Save(IReadOnlyList<ExtensionRegistryEntry> entries)

--- a/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
+++ b/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
@@ -4,10 +4,12 @@ namespace Didot.Cli;
 
 public class InstallationExtensionRegistryRepository
 {
+    public const string RegistryFileName = "didot.extensions.registry.json";
+
     public string RegistryPath { get; }
 
     public InstallationExtensionRegistryRepository()
-        : this(Path.Combine(AppContext.BaseDirectory, "didot.extensions.registry.json"))
+        : this(Path.Combine(AppContext.BaseDirectory, RegistryFileName))
     { }
 
     public InstallationExtensionRegistryRepository(string registryPath)

--- a/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
+++ b/src/Didot.Cli/InstallationExtensionRegistryRepository.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace Didot.Cli;
+
+public class InstallationExtensionRegistryRepository
+{
+    public string RegistryPath { get; }
+
+    public InstallationExtensionRegistryRepository()
+        : this(Path.Combine(AppContext.BaseDirectory, "didot.extensions.registry.json"))
+    { }
+
+    public InstallationExtensionRegistryRepository(string registryPath)
+        => RegistryPath = Path.GetFullPath(registryPath);
+
+    public virtual IReadOnlyList<ExtensionRegistryEntry> ReadAll()
+    {
+        if (!File.Exists(RegistryPath))
+            return [];
+
+        var json = File.ReadAllText(RegistryPath);
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        return JsonSerializer.Deserialize<List<ExtensionRegistryEntry>>(json) ?? [];
+    }
+
+    public virtual void Register(ExtensionRegistryEntry entry)
+    {
+        var entries = ReadAll().ToList();
+
+        if (entries.Any(x => x.Id.Equals(entry.Id, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"An extension with id '{entry.Id}' is already registered.");
+
+        if (entries.Any(x => Path.GetFullPath(x.Assembly).Equals(Path.GetFullPath(entry.Assembly), StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"The assembly '{entry.Assembly}' is already registered.");
+
+        entries.Add(entry);
+        Save(entries);
+    }
+
+    private void Save(IReadOnlyList<ExtensionRegistryEntry> entries)
+    {
+        var directory = Path.GetDirectoryName(RegistryPath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+        });
+
+        var tempPath = $"{RegistryPath}.tmp";
+        File.WriteAllText(tempPath, json);
+        File.Move(tempPath, RegistryPath, true);
+    }
+}

--- a/src/Didot.Cli/InstallationExtensionSourceResolver.cs
+++ b/src/Didot.Cli/InstallationExtensionSourceResolver.cs
@@ -1,0 +1,56 @@
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public class InstallationExtensionSourceResolver
+{
+    private InstallationExtensionRegistryRepository Repository { get; }
+    private string InstallationDirectory { get; }
+
+    public InstallationExtensionSourceResolver(InstallationExtensionRegistryRepository repository)
+        : this(repository, AppContext.BaseDirectory)
+    { }
+
+    public InstallationExtensionSourceResolver(InstallationExtensionRegistryRepository repository, string installationDirectory)
+    {
+        Repository = repository;
+        InstallationDirectory = Path.GetFullPath(installationDirectory);
+    }
+
+    public virtual bool HasRegistryFile()
+        => File.Exists(Repository.RegistryPath);
+
+    public virtual IReadOnlyList<RegisteredExtensionSource> ResolveEnabled()
+    {
+        if (!HasRegistryFile())
+            throw new RegistrationFileNotFoundException(sourcePath: Repository.RegistryPath);
+
+        IReadOnlyList<ExtensionRegistryEntry> entries;
+        try
+        {
+            entries = Repository.ReadAll();
+        }
+        catch (Exception ex)
+        {
+            throw new RegistrationFileInvalidException(Repository.RegistryPath, ex);
+        }
+
+        return entries
+            .Where(x => x.Enabled)
+            .Select(x => new RegisteredExtensionSource(
+                x.Id,
+                x.Name,
+                NormalizePath(x.Assembly)
+            ))
+            .ToList();
+    }
+
+    private string NormalizePath(string assemblyPath)
+    {
+        var trimmed = assemblyPath.Trim();
+        if (Path.IsPathRooted(trimmed))
+            return Path.GetFullPath(trimmed);
+
+        return Path.GetFullPath(Path.Combine(InstallationDirectory, trimmed));
+    }
+}

--- a/src/Didot.Cli/InstallationExtensionSourceResolver.cs
+++ b/src/Didot.Cli/InstallationExtensionSourceResolver.cs
@@ -25,24 +25,23 @@ public class InstallationExtensionSourceResolver
         if (!HasRegistryFile())
             throw new RegistrationFileNotFoundException(sourcePath: Repository.RegistryPath);
 
-        IReadOnlyList<ExtensionRegistryEntry> entries;
         try
         {
-            entries = Repository.ReadAll();
+            var entries = Repository.ReadAll();
+
+            return entries
+                .Where(x => x.Enabled)
+                .Select(x => new RegisteredExtensionSource(
+                    x.Id,
+                    x.Name,
+                    NormalizePath(x.Assembly)
+                ))
+                .ToList();
         }
         catch (Exception ex)
         {
             throw new RegistrationFileInvalidException(Repository.RegistryPath, ex);
         }
-
-        return entries
-            .Where(x => x.Enabled)
-            .Select(x => new RegisteredExtensionSource(
-                x.Id,
-                x.Name,
-                NormalizePath(x.Assembly)
-            ))
-            .ToList();
     }
 
     private string NormalizePath(string assemblyPath)

--- a/src/Didot.Cli/LoadedExtension.cs
+++ b/src/Didot.Cli/LoadedExtension.cs
@@ -1,0 +1,9 @@
+using Didot.Core;
+
+namespace Didot.Cli;
+
+public sealed record LoadedExtension(
+    string Source,
+    string TypeName,
+    IPipelineExtensionHook Instance
+);

--- a/src/Didot.Cli/Program.cs
+++ b/src/Didot.Cli/Program.cs
@@ -64,12 +64,12 @@ public class Program
         }
         catch (CliException ex)
         {
-            Console.Error.WriteLine(ex.Message);
+            await Console.Error.WriteLineAsync(ex.Message);
             return (int)ex.ExitCode;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Unexpected error: {ex.Message}");
+            await Console.Error.WriteLineAsync($"Unexpected error: {ex.Message}");
             return (int)CliExitCode.InternalError;
         }
     }

--- a/src/Didot.Cli/Program.cs
+++ b/src/Didot.Cli/Program.cs
@@ -33,9 +33,17 @@ public class Program
             {
                 services.AddLogging();
                 services.AddTransient<RenderOptions>();
+                services.AddTransient<RegisterExtensionOptions>();
+                services.AddTransient<ExtensionMetadataReader>();
+                services.AddTransient<ExtensionReferenceResolver>();
+                services.AddTransient<InstallationExtensionRegistryRepository>();
+                services.AddTransient<RegisterExtensionCommandHandler>();
+                services.AddTransient<RegisterExtensionCommand>();
+                services.AddTransient<ExtensionsCommand>();
                 services.AddTransient<RootCommand>(provider =>
-                    new RenderCommand(
+                    new CliRootCommand(
                         provider.GetRequiredService<RenderOptions>(),
+                        provider.GetRequiredService<ExtensionsCommand>(),
                         provider.GetRequiredService<ILogger<RenderCommand>>()
                     ));
             })

--- a/src/Didot.Cli/Program.cs
+++ b/src/Didot.Cli/Program.cs
@@ -37,6 +37,9 @@ public class Program
                 services.AddTransient<ExtensionMetadataReader>();
                 services.AddTransient<ExtensionReferenceResolver>();
                 services.AddTransient<InstallationExtensionRegistryRepository>();
+                services.AddTransient<InstallationExtensionSourceResolver>();
+                services.AddTransient<ExtensionAssemblyLoader>();
+                services.AddTransient<RenderCommandHandler>();
                 services.AddTransient<RegisterExtensionCommandHandler>();
                 services.AddTransient<RegisterExtensionCommand>();
                 services.AddTransient<ExtensionsCommand>();
@@ -44,6 +47,7 @@ public class Program
                     new CliRootCommand(
                         provider.GetRequiredService<RenderOptions>(),
                         provider.GetRequiredService<ExtensionsCommand>(),
+                        provider.GetRequiredService<RenderCommandHandler>(),
                         provider.GetRequiredService<ILogger<RenderCommand>>()
                     ));
             })
@@ -52,8 +56,21 @@ public class Program
         var logger = host.Services.GetRequiredService<ILogger<Program>>();
         logger.LogInformation($"Didot Command Line Interface: version {Assembly.GetExecutingAssembly().GetName().Version}");
 
-        var renderCommand = host.Services.GetRequiredService<RootCommand>();
-        var parseResult = renderCommand.Parse(args);
-        return await parseResult.InvokeAsync();
+        try
+        {
+            var renderCommand = host.Services.GetRequiredService<RootCommand>();
+            var parseResult = renderCommand.Parse(args);
+            return await parseResult.InvokeAsync();
+        }
+        catch (CliException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return (int)ex.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unexpected error: {ex.Message}");
+            return (int)CliExitCode.InternalError;
+        }
     }
 }

--- a/src/Didot.Cli/RegisterExtensionCommand.cs
+++ b/src/Didot.Cli/RegisterExtensionCommand.cs
@@ -1,0 +1,35 @@
+using System.CommandLine;
+
+namespace Didot.Cli;
+
+public class RegisterExtensionCommand : Command
+{
+    public RegisterExtensionCommand(RegisterExtensionOptions options, RegisterExtensionCommandHandler handler)
+        : base("register", "Register an extension in Didot's extension registry.")
+    {
+        Arguments.Add(options.Reference);
+        Options.Add(options.Name);
+
+        Validators.Add(result =>
+        {
+            var reference = result.GetValue(options.Reference);
+            if (string.IsNullOrWhiteSpace(reference))
+                result.AddError("The <reference> argument cannot be empty.");
+
+            var nameResult = result.GetResult(options.Name);
+            if (nameResult is not null && nameResult.Tokens.Count > 0)
+            {
+                var name = result.GetValue(options.Name);
+                if (string.IsNullOrWhiteSpace(name))
+                    result.AddError("The --name option cannot be empty when provided.");
+            }
+        });
+
+        this.SetAction(parseResult =>
+            handler.Execute(
+                parseResult.GetValue(options.Reference)!,
+                parseResult.GetValue(options.Name)
+            )
+        );
+    }
+}

--- a/src/Didot.Cli/RegisterExtensionCommandHandler.cs
+++ b/src/Didot.Cli/RegisterExtensionCommandHandler.cs
@@ -38,10 +38,20 @@ public class RegisterExtensionCommandHandler
             Console.Out.WriteLine($"Registered extension '{entry.Name}' ({entry.Id}) version {entry.Version} from '{entry.Assembly}'.");
             return 0;
         }
+        catch (Core.ExtensionException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return (int)ex.ToCliExitCode();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return (int)CliExitCode.InvalidInput;
+        }
         catch (Exception ex)
         {
             Console.Error.WriteLine(ex.Message);
-            return 1;
+            return (int)CliExitCode.InternalError;
         }
     }
 }

--- a/src/Didot.Cli/RegisterExtensionCommandHandler.cs
+++ b/src/Didot.Cli/RegisterExtensionCommandHandler.cs
@@ -1,0 +1,47 @@
+namespace Didot.Cli;
+
+public class RegisterExtensionCommandHandler
+{
+    private ExtensionReferenceResolver Resolver { get; }
+    private ExtensionMetadataReader MetadataReader { get; }
+    private InstallationExtensionRegistryRepository Repository { get; }
+
+    public RegisterExtensionCommandHandler(
+        ExtensionReferenceResolver resolver,
+        ExtensionMetadataReader metadataReader,
+        InstallationExtensionRegistryRepository repository)
+    {
+        Resolver = resolver;
+        MetadataReader = metadataReader;
+        Repository = repository;
+    }
+
+    public virtual int Execute(string reference, string? name)
+    {
+        try
+        {
+            var assemblyPath = Resolver.ResolveAssemblyPath(reference);
+            var metadata = MetadataReader.Read(assemblyPath);
+
+            var entry = new ExtensionRegistryEntry
+            {
+                Id = metadata.Id,
+                Name = string.IsNullOrWhiteSpace(name) ? metadata.Name : name.Trim(),
+                Assembly = assemblyPath,
+                Enabled = true,
+                Version = metadata.Version,
+                RegisteredAt = DateTimeOffset.UtcNow,
+            };
+
+            Repository.Register(entry);
+
+            Console.Out.WriteLine($"Registered extension '{entry.Name}' ({entry.Id}) version {entry.Version} from '{entry.Assembly}'.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+}

--- a/src/Didot.Cli/RegisterExtensionOptions.cs
+++ b/src/Didot.Cli/RegisterExtensionOptions.cs
@@ -1,0 +1,19 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace Didot.Cli;
+
+public class RegisterExtensionOptions
+{
+    public Argument<string> Reference { get; } = new("reference")
+    {
+        Description = "Extension reference (id/name, assembly path, or directory path).",
+        Arity = ArgumentArity.ExactlyOne,
+    };
+
+    public Option<string> Name { get; } = new("--name")
+    {
+        Description = "Friendly name override for the registered extension.",
+        Arity = ArgumentArity.ZeroOrOne,
+    };
+}

--- a/src/Didot.Cli/RegisteredExtensionSource.cs
+++ b/src/Didot.Cli/RegisteredExtensionSource.cs
@@ -1,0 +1,7 @@
+namespace Didot.Cli;
+
+public sealed record RegisteredExtensionSource(
+    string Id,
+    string Name,
+    string AssemblyPath
+);

--- a/src/Didot.Cli/RenderCliException.cs
+++ b/src/Didot.Cli/RenderCliException.cs
@@ -1,0 +1,14 @@
+namespace Didot.Cli;
+
+public sealed class RenderCliException : CliException
+{
+    public string? SourcePath { get; }
+
+    public RenderCliException(
+        CliExitCode exitCode,
+        string message,
+        string? sourcePath = null,
+        Exception? innerException = null)
+        : base(exitCode, message, innerException)
+        => SourcePath = sourcePath;
+}

--- a/src/Didot.Cli/RenderCommand.cs
+++ b/src/Didot.Cli/RenderCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,23 +15,39 @@ public class RenderCommand : RootCommand
 {
     public RenderCommand(RenderOptions options, ILogger<RenderCommand>? logger = null)
         : base("Didot Command Line Interface")
+        => Configure(this, options, logger);
+
+    public static void Configure(Command command, RenderOptions options, ILogger<RenderCommand>? logger = null)
     {
         options.EngineExtensions.DefaultValueFactory = _ => [];
         options.ParserExtensions.DefaultValueFactory = _ => [];
         options.ParserParams.DefaultValueFactory = _ => [];
         options.Sources.DefaultValueFactory = _ => [];
 
-        Options.Add(options.Template);
-        Options.Add(options.Engine);
-        Options.Add(options.EngineExtensions);
-        Options.Add(options.Sources);
-        Options.Add(options.StdIn);
-        Options.Add(options.Parser);
-        Options.Add(options.ParserExtensions);
-        Options.Add(options.ParserParams);
-        Options.Add(options.Output);
+        command.Options.Add(options.Template);
+        command.Options.Add(options.Engine);
+        command.Options.Add(options.EngineExtensions);
+        command.Options.Add(options.Sources);
+        command.Options.Add(options.StdIn);
+        command.Options.Add(options.Parser);
+        command.Options.Add(options.ParserExtensions);
+        command.Options.Add(options.ParserParams);
+        command.Options.Add(options.Output);
 
-        Validators.Add(result => {
+        command.Validators.Add(result =>
+        {
+            if (HasSubcommand(result))
+                return;
+
+            var template = result.GetValue(options.Template);
+            if (string.IsNullOrWhiteSpace(template))
+                result.AddError("Option '--template' is required.");
+        });
+
+        command.Validators.Add(result => {
+            if (HasSubcommand(result))
+                return;
+
             var stdIn = result.GetValue(options.StdIn);
 
             var sourcesResult = result.GetResult(options.Sources);
@@ -45,14 +62,20 @@ public class RenderCommand : RootCommand
             }
         });
 
-        Validators.Add(result => {
+        command.Validators.Add(result => {
+            if (HasSubcommand(result))
+                return;
+
             var stdIn = result.GetValue(options.StdIn);
             var parser = result.GetValue(options.Parser) ?? string.Empty;
             if (stdIn && string.IsNullOrEmpty(parser))
                 result.AddError("The --parser option is required when using --stdin to specify the input source.");
         });
 
-        Validators.Add(result => {
+        command.Validators.Add(result => {
+            if (HasSubcommand(result))
+                return;
+
             var stdIn = result.GetValue(options.StdIn);
             var sourcesResult = result.GetResult(options.Sources);
             var hasSources = sourcesResult is not null
@@ -63,7 +86,7 @@ public class RenderCommand : RootCommand
                 result.AddError("The --stdin option is required when not using --source to specify the input file(s).");
         });
 
-        this.SetAction(parseResult =>
+        command.SetAction(parseResult =>
         {
             var handler = new RenderCommandHandler(logger);
 
@@ -79,5 +102,8 @@ public class RenderCommand : RootCommand
             );
         });
     }
+
+    private static bool HasSubcommand(CommandResult result)
+        => result.Children.Any(x => x is CommandResult);
 }
 

--- a/src/Didot.Cli/RenderCommand.cs
+++ b/src/Didot.Cli/RenderCommand.cs
@@ -17,7 +17,7 @@ public class RenderCommand : RootCommand
         : base("Didot Command Line Interface")
         => Configure(this, options, logger);
 
-    public static void Configure(Command command, RenderOptions options, ILogger<RenderCommand>? logger = null)
+    public static void Configure(Command command, RenderOptions options, ILogger<RenderCommand>? logger = null, RenderCommandHandler? commandHandler = null)
     {
         options.EngineExtensions.DefaultValueFactory = _ => [];
         options.ParserExtensions.DefaultValueFactory = _ => [];
@@ -88,18 +88,33 @@ public class RenderCommand : RootCommand
 
         command.SetAction(parseResult =>
         {
-            var handler = new RenderCommandHandler(logger);
+            try
+            {
+                var handler = commandHandler ?? new RenderCommandHandler(logger);
 
-            handler.Execute(
-                parseResult.GetValue(options.Template)!,
-                parseResult.GetValue(options.Engine)!,
-                parseResult.GetValue(options.EngineExtensions) ?? [],
-                parseResult.GetValue(options.Sources) ?? [],
-                parseResult.GetValue(options.Parser)!,
-                parseResult.GetValue(options.ParserExtensions) ?? [],
-                parseResult.GetValue(options.ParserParams) ?? [],
-                parseResult.GetValue(options.Output)!
-            );
+                handler.Execute(
+                    parseResult.GetValue(options.Template)!,
+                    parseResult.GetValue(options.Engine)!,
+                    parseResult.GetValue(options.EngineExtensions) ?? [],
+                    parseResult.GetValue(options.Sources) ?? [],
+                    parseResult.GetValue(options.Parser)!,
+                    parseResult.GetValue(options.ParserExtensions) ?? [],
+                    parseResult.GetValue(options.ParserParams) ?? [],
+                    parseResult.GetValue(options.Output)!
+                );
+
+                return (int)CliExitCode.Success;
+            }
+            catch (CliException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return (int)ex.ExitCode;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unexpected error: {ex.Message}");
+                return (int)CliExitCode.InternalError;
+            }
         });
     }
 

--- a/src/Didot.Cli/RenderCommandHandler.cs
+++ b/src/Didot.Cli/RenderCommandHandler.cs
@@ -13,9 +13,18 @@ namespace Didot.Cli;
 public class RenderCommandHandler
 {
     protected ILogger<RenderCommand>? Logger { get; }
+    private InstallationExtensionSourceResolver? SourceResolver { get; }
+    private ExtensionAssemblyLoader? AssemblyLoader { get; }
 
-    public RenderCommandHandler(ILogger<RenderCommand>? logger = null)
-        => Logger = logger;
+    public RenderCommandHandler(
+        ILogger<RenderCommand>? logger = null,
+        InstallationExtensionSourceResolver? sourceResolver = null,
+        ExtensionAssemblyLoader? assemblyLoader = null)
+    {
+        Logger = logger;
+        SourceResolver = sourceResolver;
+        AssemblyLoader = assemblyLoader;
+    }
 
     public virtual void Execute(
         string template
@@ -48,7 +57,10 @@ public class RenderCommandHandler
             var templateEngine = GetTemplateEngine(engineFactory, engine, template);
             Logger?.LogInformation("Using template engine: {TemplateEngineName}.", templateEngine.GetType().Name);
 
-            var result = GetRenderedOutput(templateEngine, template, allSources);
+            var hooks = LoadExtensionHooks();
+            Logger?.LogInformation("Loaded {HookCount} extension hook(s).", hooks.Count);
+
+            var result = GetRenderedOutput(templateEngine, template, allSources, hooks);
 
             if (string.IsNullOrEmpty(output))
             {
@@ -97,7 +109,8 @@ public class RenderCommandHandler
         {
             foreach (var source in sources)
             {
-                var sourceStream = File.OpenRead(source.Value);
+                var sourceStream = OpenReadOrThrowCli(source.Value);
+
                 var parser = string.IsNullOrEmpty(parserTag)
                                 ? factory.GetByExtension(new FileInfo(source.Value).Extension)
                                 : factory.GetByTag(parserTag);
@@ -124,11 +137,11 @@ public class RenderCommandHandler
         }
     }
 
-    protected virtual string GetRenderedOutput(ITemplateEngine engine, string template, IDictionary<string, ISource> sources)
+    protected virtual string GetRenderedOutput(ITemplateEngine engine, string template, IDictionary<string, ISource> sources, IList<IPipelineExtensionHook> hooks)
     {
         try
         {
-            using var templateStream = File.OpenRead(template);
+            using var templateStream = OpenReadOrThrowCli(template);
 
             var pipeline = new RenderPipeline();
             var context = new RenderPipelineContext()
@@ -136,16 +149,90 @@ public class RenderCommandHandler
                 TemplateEngine = engine,
                 TemplateStream = templateStream,
                 Inputs = sources.ToDictionary(x => x.Key, x => (IModelInput)new SourceModelInput(x.Value)),
+                Hooks = hooks,
             };
             pipeline.Execute(context);
             return context.Output ?? string.Empty;
         }
-        catch (Exception)
-        { throw; }
         finally
         {
             foreach (var source in sources)
                 source.Value.Content.Dispose();
         }
+    }
+
+    private static FileStream OpenReadOrThrowCli(string path)
+    {
+        try
+        {
+            return File.OpenRead(path);
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw new RenderCliException(
+                CliExitCode.NotFound,
+                $"Input file '{path}' was not found.",
+                path,
+                ex);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            throw new RenderCliException(
+                CliExitCode.NotFound,
+                $"Input file '{path}' was not found.",
+                path,
+                ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new RenderCliException(
+                CliExitCode.LoadFailure,
+                $"Access denied while reading '{path}'.",
+                path,
+                ex);
+        }
+        catch (IOException ex)
+        {
+            throw new RenderCliException(
+                CliExitCode.LoadFailure,
+                $"I/O error while reading '{path}'. {ex.Message}",
+                path,
+                ex);
+        }
+    }
+
+    protected virtual IList<IPipelineExtensionHook> LoadExtensionHooks()
+    {
+        if (SourceResolver is null || AssemblyLoader is null)
+            return [];
+
+        if (!SourceResolver.HasRegistryFile())
+            return [];
+
+        IReadOnlyList<RegisteredExtensionSource> registeredSources;
+        try
+        {
+            registeredSources = SourceResolver.ResolveEnabled();
+        }
+        catch (ExtensionException ex)
+        {
+            throw ex.ToCliException();
+        }
+
+        var hooks = new List<IPipelineExtensionHook>();
+        foreach (var source in registeredSources)
+        {
+            try
+            {
+                var loadedExtension = AssemblyLoader.Load(source.AssemblyPath, source.Id);
+                hooks.Add(loadedExtension.Instance);
+            }
+            catch (ExtensionException ex)
+            {
+                throw ex.ToCliException();
+            }
+        }
+
+        return hooks;
     }
 }

--- a/src/Didot.Cli/RenderCommandHandler.cs
+++ b/src/Didot.Cli/RenderCommandHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CommandLine;
 using System.Linq;
 using System.Reflection;
@@ -42,16 +42,16 @@ public class RenderCommandHandler
 
         try
         {
-            Logger?.LogInformation("Configured {ParserExtensionCount} parser associations to file extensions.", parserExtensions.Count());
-            Logger?.LogInformation("Configured {ParserExtensionCount} parser parameters.", parserParams.Count());
+            Logger?.LogInformation("Configured {ParserExtensionCount} parser associations to file extensions.", parserExtensions.Count);
+            Logger?.LogInformation("Configured {ParserExtensionCount} parser parameters.", parserParams.Count);
             foreach (var param in parserParams)
                 Logger?.LogInformation("Parser parameter: {ParserParamKey}={ParserParamValue}.", param.Key, param.Value);
             var parserFactory = GetSourceParserFactory(parserExtensions, parserParams);
 
-            Logger?.LogInformation("Configured {EnginerExtensionCount} template engine associations to file extensions.", engineExtensions.Count());
+            Logger?.LogInformation("Configured {EnginerExtensionCount} template engine associations to file extensions.", engineExtensions.Count);
             var engineFactory = GetTemplateEngineFactory(engineExtensions);
 
-            Logger?.LogInformation("Configured {DataSourceFileCount} data source file(s) for processing.", sources.Count());
+            Logger?.LogInformation("Configured {DataSourceFileCount} data source file(s) for processing.", sources.Count);
             var allSources = GetSources(sources, parserFactory, parser);
 
             var templateEngine = GetTemplateEngine(engineFactory, engine, template);

--- a/src/Didot.Cli/RenderCommandHandler.cs
+++ b/src/Didot.Cli/RenderCommandHandler.cs
@@ -128,9 +128,17 @@ public class RenderCommandHandler
     {
         try
         {
-            var printer = new Printer(engine);
             using var templateStream = File.OpenRead(template);
-            return printer.Render(templateStream, sources);
+
+            var pipeline = new RenderPipeline();
+            var context = new RenderPipelineContext()
+            {
+                TemplateEngine = engine,
+                TemplateStream = templateStream,
+                Inputs = sources.ToDictionary(x => x.Key, x => (IModelInput)new SourceModelInput(x.Value)),
+            };
+            pipeline.Execute(context);
+            return context.Output ?? string.Empty;
         }
         catch (Exception)
         { throw; }

--- a/src/Didot.Cli/RenderOptions.cs
+++ b/src/Didot.Cli/RenderOptions.cs
@@ -16,7 +16,7 @@ public class RenderOptions
     )
     {
         Description = "Path to the template file.",
-        Required = true,
+        Required = false,
         Arity = ArgumentArity.ExactlyOne
     };
 

--- a/src/Didot.Core/ApplyHooksStep.cs
+++ b/src/Didot.Core/ApplyHooksStep.cs
@@ -1,0 +1,13 @@
+namespace Didot.Core;
+
+public class ApplyHooksStep : IPipelineStep<RenderPipelineContext>
+{
+    public void Execute(RenderPipelineContext context)
+    {
+        var model = context.Model;
+        foreach (var hook in context.Hooks)
+            model = hook.Apply(model) ?? throw new InvalidOperationException($"Hook '{hook.GetType().Name}' returned a null model.");
+
+        context.Model = model;
+    }
+}

--- a/src/Didot.Core/DidotExtensionAttribute.cs
+++ b/src/Didot.Core/DidotExtensionAttribute.cs
@@ -1,6 +1,6 @@
 namespace Didot.Core;
 
-[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class, AllowMultiple = false)]
 public sealed class DidotExtensionAttribute(string id, string name) : Attribute
 {
     public string Id { get; } = string.IsNullOrWhiteSpace(id)

--- a/src/Didot.Core/DidotExtensionAttribute.cs
+++ b/src/Didot.Core/DidotExtensionAttribute.cs
@@ -1,0 +1,15 @@
+namespace Didot.Core;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class DidotExtensionAttribute(string id, string name) : Attribute
+{
+    public string Id { get; } = string.IsNullOrWhiteSpace(id)
+        ? throw new ArgumentException("Extension id cannot be null or whitespace.", nameof(id))
+        : id.Trim();
+
+    public string Name { get; } = string.IsNullOrWhiteSpace(name)
+        ? throw new ArgumentException("Extension name cannot be null or whitespace.", nameof(name))
+        : name.Trim();
+
+    public string? Version { get; init; }
+}

--- a/src/Didot.Core/ExtensionException.cs
+++ b/src/Didot.Core/ExtensionException.cs
@@ -1,0 +1,97 @@
+namespace Didot.Core;
+
+public abstract class ExtensionException : Exception
+{
+    public string? SourcePath { get; }
+
+    protected ExtensionException(
+        string message,
+        string? sourcePath = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        SourcePath = sourcePath;
+    }
+
+    protected static string WithSourcePath(string message, string? sourcePath)
+        => string.IsNullOrWhiteSpace(sourcePath)
+            ? message
+            : $"{message} Source path: '{sourcePath}'.";
+}
+
+public sealed class RegistrationFileNotFoundException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public RegistrationFileNotFoundException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("No extension registry file was found.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class RegistrationFileInvalidException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public RegistrationFileInvalidException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("The extension registry file is invalid.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class ExtensionSourceNotFoundException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public ExtensionSourceNotFoundException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("The extension source was not found.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class AssemblyLoadFailedException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public AssemblyLoadFailedException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("Unable to load extension assembly.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class ExtensionTypeNotFoundException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public ExtensionTypeNotFoundException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("No compatible extension type was found.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class ExtensionTypeAmbiguousException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public ExtensionTypeAmbiguousException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("Multiple compatible extension types were found.", sourcePath), sourcePath, innerException)
+    { }
+}
+
+public sealed class ExtensionInstantiationFailedException(
+    string message,
+    string? sourcePath = null,
+    Exception? innerException = null)
+    : ExtensionException(message, sourcePath, innerException)
+{
+    public ExtensionInstantiationFailedException(string? sourcePath = null, Exception? innerException = null)
+        : this(WithSourcePath("Failed to instantiate extension type.", sourcePath), sourcePath, innerException)
+    { }
+}

--- a/src/Didot.Core/IModelInput.cs
+++ b/src/Didot.Core/IModelInput.cs
@@ -1,0 +1,6 @@
+namespace Didot.Core;
+
+public interface IModelInput
+{
+    object Parse();
+}

--- a/src/Didot.Core/IPipeline.cs
+++ b/src/Didot.Core/IPipeline.cs
@@ -1,0 +1,6 @@
+namespace Didot.Core;
+
+public interface IPipeline<TContext> where TContext : IPipelineContext
+{
+    void Execute(TContext context);
+}

--- a/src/Didot.Core/IPipeline.cs
+++ b/src/Didot.Core/IPipeline.cs
@@ -1,6 +1,6 @@
 namespace Didot.Core;
 
-public interface IPipeline<TContext> where TContext : IPipelineContext
+public interface IPipeline<in TContext> where TContext : IPipelineContext
 {
     void Execute(TContext context);
 }

--- a/src/Didot.Core/IPipelineContext.cs
+++ b/src/Didot.Core/IPipelineContext.cs
@@ -1,0 +1,4 @@
+namespace Didot.Core;
+
+public interface IPipelineContext
+{ }

--- a/src/Didot.Core/IPipelineExtensionHook.cs
+++ b/src/Didot.Core/IPipelineExtensionHook.cs
@@ -1,0 +1,6 @@
+namespace Didot.Core;
+
+public interface IPipelineExtensionHook
+{
+    object Apply(object model);
+}

--- a/src/Didot.Core/IPipelineStep.cs
+++ b/src/Didot.Core/IPipelineStep.cs
@@ -1,6 +1,6 @@
 namespace Didot.Core;
 
-public interface IPipelineStep<TContext> where TContext : IPipelineContext
+public interface IPipelineStep<in TContext> where TContext : IPipelineContext
 {
     void Execute(TContext context);
 }

--- a/src/Didot.Core/IPipelineStep.cs
+++ b/src/Didot.Core/IPipelineStep.cs
@@ -1,0 +1,6 @@
+namespace Didot.Core;
+
+public interface IPipelineStep<TContext> where TContext : IPipelineContext
+{
+    void Execute(TContext context);
+}

--- a/src/Didot.Core/ParseModelStep.cs
+++ b/src/Didot.Core/ParseModelStep.cs
@@ -1,0 +1,25 @@
+namespace Didot.Core;
+
+public class ParseModelStep : IPipelineStep<RenderPipelineContext>
+{
+    public void Execute(RenderPipelineContext context)
+    {
+        if (context.Model is not null)
+            return;
+
+        if (context.Inputs.Count == 0)
+            throw new InvalidOperationException("No model inputs were provided to parse.");
+
+        if (context.Inputs.Count == 1 && string.IsNullOrEmpty(context.Inputs.First().Key))
+        {
+            context.Model = context.Inputs.First().Value.Parse();
+            return;
+        }
+
+        var model = new Dictionary<string, object>();
+        foreach (var input in context.Inputs)
+            model.Add(input.Key, input.Value.Parse());
+
+        context.Model = model;
+    }
+}

--- a/src/Didot.Core/Printer.cs
+++ b/src/Didot.Core/Printer.cs
@@ -33,10 +33,10 @@ public class Printer
     }
 
     public string Render(string template, object model)
-        => TemplateEngine.Render(template, model);
+        => RenderPipeline(template, model);
 
     public string Render(Stream template, object model)
-        => TemplateEngine.Render(template, model);
+        => RenderPipeline(template, model);
 
     public string Render(string template, string content, ISourceParser parser)
         => RenderPipeline(template, new Dictionary<string, IModelInput>()
@@ -73,6 +73,8 @@ public class Printer
 
     private static Dictionary<string, IModelInput> ToModelInputs(IDictionary<string, ISource> sources)
     {
+        ArgumentNullException.ThrowIfNull(sources);
+
         var inputs = new Dictionary<string, IModelInput>();
         foreach (var source in sources)
             inputs.Add(source.Key, new SourceModelInput(source.Value));
@@ -99,6 +101,32 @@ public class Printer
             TemplateEngine = TemplateEngine,
             TemplateStream = template,
             Inputs = inputs,
+            Hooks = Hooks,
+        };
+        BuildRenderPipeline().Execute(context);
+        return context.Output ?? string.Empty;
+    }
+
+    private string RenderPipeline(string template, object model)
+    {
+        var context = new RenderPipelineContext()
+        {
+            TemplateEngine = TemplateEngine,
+            Template = template,
+            Model = model,
+            Hooks = Hooks,
+        };
+        BuildRenderPipeline().Execute(context);
+        return context.Output ?? string.Empty;
+    }
+
+    private string RenderPipeline(Stream template, object model)
+    {
+        var context = new RenderPipelineContext()
+        {
+            TemplateEngine = TemplateEngine,
+            TemplateStream = template,
+            Model = model,
             Hooks = Hooks,
         };
         BuildRenderPipeline().Execute(context);

--- a/src/Didot.Core/Printer.cs
+++ b/src/Didot.Core/Printer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,8 +25,7 @@ public class Printer
 
     public Printer AddHooks(IEnumerable<IPipelineExtensionHook> hooks)
     {
-        if (hooks is null)
-            throw new ArgumentNullException(nameof(hooks));
+        ArgumentNullException.ThrowIfNull(hooks);
 
         foreach (var hook in hooks)
             AddHook(hook);

--- a/src/Didot.Core/Printer.cs
+++ b/src/Didot.Core/Printer.cs
@@ -3,17 +3,36 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Didot.Core;
-using SmartFormat.Core.Extensions;
 
 namespace Didot.Core;
 
 public class Printer
 {
     protected ITemplateEngine TemplateEngine { get; }
+    private IList<IPipelineExtensionHook> Hooks { get; } = [];
 
     public Printer(ITemplateEngine templateEngine)
         => (TemplateEngine) = (templateEngine);
+
+    public Printer AddHook(IPipelineExtensionHook hook)
+    {
+        if (hook is null)
+            throw new ArgumentNullException(nameof(hook));
+
+        Hooks.Add(hook);
+        return this;
+    }
+
+    public Printer AddHooks(IEnumerable<IPipelineExtensionHook> hooks)
+    {
+        if (hooks is null)
+            throw new ArgumentNullException(nameof(hooks));
+
+        foreach (var hook in hooks)
+            AddHook(hook);
+
+        return this;
+    }
 
     public string Render(string template, object model)
         => TemplateEngine.Render(template, model);
@@ -22,34 +41,69 @@ public class Printer
         => TemplateEngine.Render(template, model);
 
     public string Render(string template, string content, ISourceParser parser)
-        => Render(template, new { model = parser.Parse(content)});
+        => RenderPipeline(template, new Dictionary<string, IModelInput>()
+        {
+            [string.Empty] = new StringModelInput(content, parser),
+        });
 
     public string Render(Stream template, string content, ISourceParser parser)
-        => Render(template, new { model = parser.Parse(content) });
+        => RenderPipeline(template, new Dictionary<string, IModelInput>()
+        {
+            [string.Empty] = new StringModelInput(content, parser),
+        });
 
     public string Render(string template, Stream content, ISourceParser parser)
-        => Render(template, new { model = parser.Parse(content) });
+        => RenderPipeline(template, new Dictionary<string, IModelInput>()
+        {
+            [string.Empty] = new StreamModelInput(content, parser),
+        });
 
     public string Render(Stream template, Stream content, ISourceParser parser)
-        => Render(template, new { model = parser.Parse(content) });
+        => RenderPipeline(template, new Dictionary<string, IModelInput>()
+        {
+            [string.Empty] = new StreamModelInput(content, parser),
+        });
 
     public string Render(string template, IDictionary<string, ISource> sources)
-        => Render(template, new { model = BuildModel(sources) });
+        => RenderPipeline(template, ToModelInputs(sources));
 
     public string Render(Stream template, IDictionary<string, ISource> sources)
-        => Render(template, new { model = BuildModel(sources) });
+        => RenderPipeline(template, ToModelInputs(sources));
 
-    private object BuildModel(IDictionary<string, ISource> sources)
+    protected virtual IPipeline<RenderPipelineContext> BuildRenderPipeline()
+        => new RenderPipeline();
+
+    private Dictionary<string, IModelInput> ToModelInputs(IDictionary<string, ISource> sources)
     {
-        if (sources.Count == 1 && string.IsNullOrEmpty(sources.First().Key))
-            return sources.First().Value.Parser.Parse(sources.First().Value.Content);
-
-        var model = new Dictionary<string, object>();
+        var inputs = new Dictionary<string, IModelInput>();
         foreach (var source in sources)
+            inputs.Add(source.Key, new SourceModelInput(source.Value));
+        return inputs;
+    }
+
+    private string RenderPipeline(string template, IDictionary<string, IModelInput> inputs)
+    {
+        var context = new RenderPipelineContext()
         {
-            model.Add(source.Key, source.Value.Parser.Parse(source.Value.Content));
-            source.Value.Content.Dispose();
-        }
-        return model;
+            TemplateEngine = TemplateEngine,
+            Template = template,
+            Inputs = inputs,
+            Hooks = Hooks,
+        };
+        BuildRenderPipeline().Execute(context);
+        return context.Output ?? string.Empty;
+    }
+
+    private string RenderPipeline(Stream template, IDictionary<string, IModelInput> inputs)
+    {
+        var context = new RenderPipelineContext()
+        {
+            TemplateEngine = TemplateEngine,
+            TemplateStream = template,
+            Inputs = inputs,
+            Hooks = Hooks,
+        };
+        BuildRenderPipeline().Execute(context);
+        return context.Output ?? string.Empty;
     }
 }

--- a/src/Didot.Core/Printer.cs
+++ b/src/Didot.Core/Printer.cs
@@ -16,8 +16,7 @@ public class Printer
 
     public Printer AddHook(IPipelineExtensionHook hook)
     {
-        if (hook is null)
-            throw new ArgumentNullException(nameof(hook));
+        ArgumentNullException.ThrowIfNull(hook);
 
         Hooks.Add(hook);
         return this;
@@ -72,7 +71,7 @@ public class Printer
     protected virtual IPipeline<RenderPipelineContext> BuildRenderPipeline()
         => new RenderPipeline();
 
-    private Dictionary<string, IModelInput> ToModelInputs(IDictionary<string, ISource> sources)
+    private static Dictionary<string, IModelInput> ToModelInputs(IDictionary<string, ISource> sources)
     {
         var inputs = new Dictionary<string, IModelInput>();
         foreach (var source in sources)

--- a/src/Didot.Core/RenderPipeline.cs
+++ b/src/Didot.Core/RenderPipeline.cs
@@ -1,0 +1,23 @@
+namespace Didot.Core;
+
+public class RenderPipeline : IPipeline<RenderPipelineContext>
+{
+    private IList<IPipelineStep<RenderPipelineContext>> Steps { get; }
+
+    public RenderPipeline()
+        : this([
+            new ParseModelStep(),
+            new ApplyHooksStep(),
+            new RenderTemplateStep(),
+        ])
+    { }
+
+    public RenderPipeline(IEnumerable<IPipelineStep<RenderPipelineContext>> steps)
+        => Steps = [.. steps];
+
+    public void Execute(RenderPipelineContext context)
+    {
+        foreach (var step in Steps)
+            step.Execute(context);
+    }
+}

--- a/src/Didot.Core/RenderPipeline.cs
+++ b/src/Didot.Core/RenderPipeline.cs
@@ -13,7 +13,10 @@ public class RenderPipeline : IPipeline<RenderPipelineContext>
     { }
 
     public RenderPipeline(IEnumerable<IPipelineStep<RenderPipelineContext>> steps)
-        => Steps = [.. steps];
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        Steps = [.. steps];
+    }
 
     public void Execute(RenderPipelineContext context)
     {

--- a/src/Didot.Core/RenderPipelineContext.cs
+++ b/src/Didot.Core/RenderPipelineContext.cs
@@ -1,0 +1,12 @@
+namespace Didot.Core;
+
+public class RenderPipelineContext : IPipelineContext
+{
+    public required ITemplateEngine TemplateEngine { get; init; }
+    public string? Template { get; init; }
+    public Stream? TemplateStream { get; init; }
+    public IDictionary<string, IModelInput> Inputs { get; init; } = new Dictionary<string, IModelInput>();
+    public IList<IPipelineExtensionHook> Hooks { get; init; } = [];
+    public object? Model { get; set; }
+    public string? Output { get; set; }
+}

--- a/src/Didot.Core/RenderTemplateStep.cs
+++ b/src/Didot.Core/RenderTemplateStep.cs
@@ -1,0 +1,16 @@
+namespace Didot.Core;
+
+public class RenderTemplateStep : IPipelineStep<RenderPipelineContext>
+{
+    public void Execute(RenderPipelineContext context)
+    {
+        var wrappedModel = new { model = context.Model };
+
+        if (context.Template is not null)
+            context.Output = context.TemplateEngine.Render(context.Template, wrappedModel);
+        else if (context.TemplateStream is not null)
+            context.Output = context.TemplateEngine.Render(context.TemplateStream, wrappedModel);
+        else
+            throw new InvalidOperationException("No template content was provided to render.");
+    }
+}

--- a/src/Didot.Core/SourceModelInput.cs
+++ b/src/Didot.Core/SourceModelInput.cs
@@ -5,7 +5,10 @@ public class SourceModelInput : IModelInput
     private ISource Source { get; }
 
     public SourceModelInput(ISource source)
-        => Source = source;
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        Source = source;
+    }
 
     public object Parse()
         => Source.Parser.Parse(Source.Content);

--- a/src/Didot.Core/SourceModelInput.cs
+++ b/src/Didot.Core/SourceModelInput.cs
@@ -1,0 +1,12 @@
+namespace Didot.Core;
+
+public class SourceModelInput : IModelInput
+{
+    private ISource Source { get; }
+
+    public SourceModelInput(ISource source)
+        => Source = source;
+
+    public object Parse()
+        => Source.Parser.Parse(Source.Content);
+}

--- a/src/Didot.Core/StreamModelInput.cs
+++ b/src/Didot.Core/StreamModelInput.cs
@@ -6,7 +6,11 @@ public class StreamModelInput : IModelInput
     private ISourceParser Parser { get; }
 
     public StreamModelInput(Stream content, ISourceParser parser)
-        => (Content, Parser) = (content, parser);
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(parser);
+        (Content, Parser) = (content, parser);
+    }
 
     public object Parse()
         => Parser.Parse(Content);

--- a/src/Didot.Core/StreamModelInput.cs
+++ b/src/Didot.Core/StreamModelInput.cs
@@ -1,0 +1,13 @@
+namespace Didot.Core;
+
+public class StreamModelInput : IModelInput
+{
+    private Stream Content { get; }
+    private ISourceParser Parser { get; }
+
+    public StreamModelInput(Stream content, ISourceParser parser)
+        => (Content, Parser) = (content, parser);
+
+    public object Parse()
+        => Parser.Parse(Content);
+}

--- a/src/Didot.Core/StringModelInput.cs
+++ b/src/Didot.Core/StringModelInput.cs
@@ -6,7 +6,11 @@ public class StringModelInput : IModelInput
     private ISourceParser Parser { get; }
 
     public StringModelInput(string content, ISourceParser parser)
-        => (Content, Parser) = (content, parser);
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(parser);
+        (Content, Parser) = (content, parser);
+    }
 
     public object Parse()
         => Parser.Parse(Content);

--- a/src/Didot.Core/StringModelInput.cs
+++ b/src/Didot.Core/StringModelInput.cs
@@ -1,0 +1,13 @@
+namespace Didot.Core;
+
+public class StringModelInput : IModelInput
+{
+    private string Content { get; }
+    private ISourceParser Parser { get; }
+
+    public StringModelInput(string content, ISourceParser parser)
+        => (Content, Parser) = (content, parser);
+
+    public object Parse()
+        => Parser.Parse(Content);
+}

--- a/testing/Didot.Cli.Testing/AssemblyInfo.cs
+++ b/testing/Didot.Cli.Testing/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Didot.Core;
+
+[assembly: DidotExtension("didot.cli.testing.extension", "Cli Testing Extension")]

--- a/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
+++ b/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
@@ -46,6 +46,7 @@ public class ExtensionRegistrationServicesTests
     }
 
     [Test]
+    [NonParallelizable]
     public void ReferenceResolver_NonPathWithMultipleMatches_Throws()
     {
         var sourceAssembly = Assembly.GetExecutingAssembly().Location;

--- a/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
+++ b/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
@@ -1,0 +1,167 @@
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Didot.Cli.Testing.Extensions;
+
+public class ExtensionRegistrationServicesTests
+{
+    [Test]
+    public void MetadataReader_WithoutVersionInAttribute_FallsBackToAssemblyVersion()
+    {
+        var reader = new Cli.ExtensionMetadataReader();
+        var assemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        var metadata = reader.Read(assemblyPath);
+
+        Assert.That(metadata.Id, Is.EqualTo("didot.cli.testing.extension"));
+        Assert.That(metadata.Name, Is.EqualTo("Cli Testing Extension"));
+        Assert.That(metadata.Version, Is.EqualTo(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0.0"));
+    }
+
+    [Test]
+    public void ReferenceResolver_ExplicitDllPath_ReturnsAbsolutePath()
+    {
+        var reader = new Cli.ExtensionMetadataReader();
+        var resolver = new Cli.ExtensionReferenceResolver(reader, Path.GetTempPath());
+
+        var sourceAssembly = Assembly.GetExecutingAssembly().Location;
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"didot-ext-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            var destination = Path.Combine(tempDirectory, "Didot.Extension.dll");
+            File.Copy(sourceAssembly, destination, true);
+
+            var resolved = resolver.ResolveAssemblyPath(destination);
+
+            Assert.That(resolved, Is.EqualTo(Path.GetFullPath(destination)));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+                Directory.Delete(tempDirectory, true);
+        }
+    }
+
+    [Test]
+    public void ReferenceResolver_NonPathWithMultipleMatches_Throws()
+    {
+        var sourceAssembly = Assembly.GetExecutingAssembly().Location;
+        var rootDirectory = Path.Combine(Path.GetTempPath(), $"didot-ext-test-{Guid.NewGuid():N}");
+        var extensionsDirectory = Path.Combine(rootDirectory, "extensions");
+        Directory.CreateDirectory(extensionsDirectory);
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            File.Copy(sourceAssembly, Path.Combine(rootDirectory, "A.dll"), true);
+            File.Copy(sourceAssembly, Path.Combine(extensionsDirectory, "B.dll"), true);
+
+            Directory.SetCurrentDirectory(rootDirectory);
+            var reader = new Cli.ExtensionMetadataReader();
+            var resolver = new Cli.ExtensionReferenceResolver(reader, Path.Combine(rootDirectory, "install"));
+
+            Assert.That(
+                () => resolver.ResolveAssemblyPath("didot.cli.testing.extension"),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Multiple extensions match")
+            );
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(rootDirectory))
+                Directory.Delete(rootDirectory, true);
+        }
+    }
+
+    [Test]
+    public void InstallationRegistryRepository_RegisterAndRead_Success()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"didot-ext-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        var registryPath = Path.Combine(directory, "didot.extensions.registry.json");
+        var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+
+        try
+        {
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.expressif",
+                Name = "Expressif",
+                Assembly = @"C:\\extensions\\Didot.Expressif.dll",
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var entries = repository.ReadAll();
+            Assert.That(entries, Has.Count.EqualTo(1));
+            Assert.That(entries[0].Id, Is.EqualTo("didot.expressif"));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    [Test]
+    public void InstallationRegistryRepository_RegisterDuplicateId_Throws()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"didot-ext-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        var registryPath = Path.Combine(directory, "didot.extensions.registry.json");
+        var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+
+        try
+        {
+            var first = new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.expressif",
+                Name = "Expressif",
+                Assembly = @"C:\extensions\Didot.Expressif.dll",
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            };
+
+            var duplicateId = new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.expressif",
+                Name = "Expressif 2",
+                Assembly = @"C:\extensions\Didot.Expressif2.dll",
+                Enabled = true,
+                Version = "1.0.1",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            };
+
+            repository.Register(first);
+
+            Assert.That(
+                () => repository.Register(duplicateId),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("already registered")
+            );
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    [Test]
+    public void MetadataReader_WhenAttributeMissing_ReturnsError()
+    {
+        var reader = new Cli.ExtensionMetadataReader();
+        var assemblyPath = typeof(Cli.Program).Assembly.Location;
+
+        var success = reader.TryRead(assemblyPath, out var metadata, out var error);
+
+        Assert.That(success, Is.False);
+        Assert.That(metadata, Is.Null);
+        Assert.That(error, Does.Contain("DidotExtensionAttribute"));
+    }
+}

--- a/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
+++ b/testing/Didot.Cli.Testing/Extensions/ExtensionRegistrationServicesTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Didot.Core;
 using NUnit.Framework;
 
 namespace Didot.Cli.Testing.Extensions;
@@ -163,5 +164,73 @@ public class ExtensionRegistrationServicesTests
         Assert.That(success, Is.False);
         Assert.That(metadata, Is.Null);
         Assert.That(error, Does.Contain("DidotExtensionAttribute"));
+    }
+
+    [Test]
+    public void ExtensionAssemblyLoader_Load_WithCompatibleType_Success()
+    {
+        var loader = new Cli.ExtensionAssemblyLoader();
+        var assemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        var extension = loader.Load(assemblyPath, "didot.cli.testing.extension");
+
+        Assert.That(extension, Is.Not.Null);
+        Assert.That(extension.Instance, Is.TypeOf<PipelineHookForE2eTests>());
+    }
+
+    [Test]
+    public void ExtensionAssemblyLoader_Load_WithoutCompatibleType_Failure()
+    {
+        var loader = new Cli.ExtensionAssemblyLoader();
+        var assemblyPath = typeof(Cli.Program).Assembly.Location;
+
+        Assert.That(
+            () => loader.Load(assemblyPath),
+            Throws.TypeOf<ExtensionTypeNotFoundException>());
+    }
+
+    [Test]
+    public void RenderCommandHandler_LoadExtensionHooks_LoadsRegisteredHook()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"didot-ext-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var registryPath = Path.Combine(directory, Cli.InstallationExtensionRegistryRepository.RegistryFileName);
+
+        try
+        {
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.cli.testing.extension",
+                Name = "Pipeline hook",
+                Assembly = Assembly.GetExecutingAssembly().Location,
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var resolver = new Cli.InstallationExtensionSourceResolver(repository, directory);
+            var loader = new Cli.ExtensionAssemblyLoader();
+            var handler = new RenderCommandHandlerProbe(resolver, loader);
+
+            var hooks = handler.InvokeLoadExtensionHooks();
+
+            Assert.That(hooks, Has.Count.EqualTo(1));
+            Assert.That(hooks[0], Is.TypeOf<PipelineHookForE2eTests>());
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    private sealed class RenderCommandHandlerProbe(
+        Cli.InstallationExtensionSourceResolver resolver,
+        Cli.ExtensionAssemblyLoader loader)
+        : Cli.RenderCommandHandler(null, resolver, loader)
+    {
+        public IList<IPipelineExtensionHook> InvokeLoadExtensionHooks()
+            => LoadExtensionHooks();
     }
 }

--- a/testing/Didot.Cli.Testing/Extensions/ExtensionsCommandParsingTests.cs
+++ b/testing/Didot.Cli.Testing/Extensions/ExtensionsCommandParsingTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+namespace Didot.Cli.Testing.Extensions;
+
+public class ExtensionsCommandParsingTests
+{
+    [Test]
+    public void RootCommand_WithoutSubcommand_KeepsLegacyRenderParsing()
+    {
+        var root = BuildRootCommand();
+
+        var result = root.Parse(new[] { "--template=file1.txt", "--stdin", "--parser=json" });
+
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+    }
+
+    [Test]
+    public void ExtensionsRegister_WithReference_ParsesSuccessfully()
+    {
+        var root = BuildRootCommand();
+
+        var result = root.Parse(new[] { "extensions", "register", "Didot.Expressif" });
+
+        Assert.That(result.Errors, Is.Null.Or.Empty);
+    }
+
+    private static Cli.CliRootCommand BuildRootCommand()
+    {
+        var registerOptions = new Cli.RegisterExtensionOptions();
+        var metadataReader = new Cli.ExtensionMetadataReader();
+        var resolver = new Cli.ExtensionReferenceResolver(metadataReader, Path.GetTempPath());
+        var repository = new Cli.InstallationExtensionRegistryRepository(Path.Combine(Path.GetTempPath(), $"didot-reg-{Guid.NewGuid():N}.json"));
+        var handler = new Cli.RegisterExtensionCommandHandler(resolver, metadataReader, repository);
+        var registerCommand = new Cli.RegisterExtensionCommand(registerOptions, handler);
+        var extensionsCommand = new Cli.ExtensionsCommand(registerCommand);
+
+        return new Cli.CliRootCommand(new Cli.RenderOptions(), extensionsCommand);
+    }
+}

--- a/testing/Didot.Cli.Testing/Extensions/PipelineHookForE2eTests.cs
+++ b/testing/Didot.Cli.Testing/Extensions/PipelineHookForE2eTests.cs
@@ -1,0 +1,80 @@
+using Didot.Core;
+
+namespace Didot.Cli.Testing.Extensions;
+
+[DidotExtension("didot.cli.testing.extension", "Cli Testing Hook")]
+public sealed class PipelineHookForE2eTests : IPipelineExtensionHook
+{
+    public object Apply(object model)
+    {
+        if (!TryReadModel(model, out var firstName, out var lastName))
+            return model;
+
+        return new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["fullname"] = $"{firstName} {lastName}".Trim(),
+        };
+    }
+
+    private static bool TryReadModel(object model, out string firstName, out string lastName)
+    {
+        firstName = string.Empty;
+        lastName = string.Empty;
+
+        if (model is IDictionary<string, object?> nullableDictionary)
+            return TryGetValue(nullableDictionary, "firstname", out firstName)
+                && TryGetValue(nullableDictionary, "lastname", out lastName);
+
+        if (model is System.Collections.IDictionary legacyDictionary)
+            return TryGetValue(legacyDictionary, "firstname", out firstName)
+                && TryGetValue(legacyDictionary, "lastname", out lastName);
+
+        return false;
+    }
+
+    private static bool TryGetValue(IDictionary<string, object?> dictionary, string key, out string value)
+    {
+        value = string.Empty;
+
+        if (!dictionary.TryGetValue(key, out var item)
+            && !dictionary.TryGetValue(key.ToLowerInvariant(), out item)
+            && !dictionary.TryGetValue(key.ToUpperInvariant(), out item)
+            && !dictionary.TryGetValue(char.ToUpperInvariant(key[0]) + key[1..], out item)
+            && !dictionary.TryGetValue(char.ToLowerInvariant(key[0]) + key[1..], out item))
+        {
+            return false;
+        }
+
+        value = item?.ToString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryGetValue(System.Collections.IDictionary dictionary, string key, out string value)
+    {
+        value = string.Empty;
+        if (!dictionary.Contains(key)
+            && !dictionary.Contains(key.ToLowerInvariant())
+            && !dictionary.Contains(key.ToUpperInvariant())
+            && !dictionary.Contains(char.ToUpperInvariant(key[0]) + key[1..])
+            && !dictionary.Contains(char.ToLowerInvariant(key[0]) + key[1..]))
+        {
+            return false;
+        }
+
+        var item = dictionary[key]
+            ?? dictionary[key.ToLowerInvariant()]
+            ?? dictionary[key.ToUpperInvariant()]
+            ?? dictionary[char.ToUpperInvariant(key[0]) + key[1..]]
+            ?? dictionary[char.ToLowerInvariant(key[0]) + key[1..]];
+
+        value = item?.ToString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+}
+
+[DidotExtension("didot.cli.testing.throwing", "Cli Testing Throwing Hook")]
+public sealed class ThrowingPipelineHookForE2eTests : IPipelineExtensionHook
+{
+    public object Apply(object model)
+        => throw new InvalidOperationException("hook was applied");
+}

--- a/testing/Didot.Cli.Testing/ProgramTests.cs
+++ b/testing/Didot.Cli.Testing/ProgramTests.cs
@@ -42,6 +42,35 @@ public class ProgramTests
         return reader.ReadToEnd().Standardize();
     }
 
+    private static string GetInstallationRegistryPath()
+        => Path.Combine(AppContext.BaseDirectory, Cli.InstallationExtensionRegistryRepository.RegistryFileName);
+
+    private static async Task ExecuteWithIsolatedRegistry(Func<string, Task> action)
+    {
+        var registryPath = GetInstallationRegistryPath();
+        var backupPath = string.Empty;
+
+        if (File.Exists(registryPath))
+        {
+            backupPath = $"{registryPath}.{Guid.NewGuid():N}.bak";
+            File.Copy(registryPath, backupPath, true);
+            File.Delete(registryPath);
+        }
+
+        try
+        {
+            await action(registryPath);
+        }
+        finally
+        {
+            if (File.Exists(registryPath))
+                File.Delete(registryPath);
+
+            if (!string.IsNullOrEmpty(backupPath) && File.Exists(backupPath))
+                File.Move(backupPath, registryPath, true);
+        }
+    }
+
     [SetUp]
     public void SetUp()
     {
@@ -71,8 +100,161 @@ public class ProgramTests
 
         ErrorWriter.Dispose();
         ErrorStream.Dispose();
-        Console.SetOut(OriginalError);
+        Console.SetError(OriginalError);
     }
+
+    [Test]
+    [NonParallelizable]
+    public async Task Main_ExtensionsRegister_WritesInstallationRegistry()
+        => await ExecuteWithIsolatedRegistry(async registryPath =>
+        {
+            var extensionPath = typeof(Extensions.PipelineHookForE2eTests).Assembly.Location;
+
+            var exitCode = await Program.Main([
+                "extensions", "register", extensionPath, "--name", "Hook E2E"
+            ]);
+
+            Assert.That(exitCode, Is.Zero, message: ReadErrorStream());
+            Assert.That(File.Exists(registryPath), Is.True);
+
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            var entries = repository.ReadAll();
+            Assert.That(entries, Has.Count.EqualTo(1));
+            Assert.That(entries[0].Assembly, Is.EqualTo(Path.GetFullPath(extensionPath)));
+            Assert.That(entries[0].Name, Is.EqualTo("Hook E2E"));
+        });
+
+    [Test]
+    [NonParallelizable]
+    public async Task Main_Render_WithRegisteredExtension_AppliesHook()
+        => await ExecuteWithIsolatedRegistry(async registryPath =>
+        {
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.cli.testing.extension",
+                Name = "Cli Testing Extension",
+                Assembly = typeof(Extensions.PipelineHookForE2eTests).Assembly.Location,
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var directory = Path.Combine(Path.GetTempPath(), $"didot-e2e-hook-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                File.WriteAllText(Path.Combine(directory, "template.hbs"), "{{model.fullname}}");
+                File.WriteAllText(Path.Combine(directory, "source.json"), "{\"firstname\":\"Ada\",\"lastname\":\"Lovelace\"}");
+
+                var originalCurrentDirectory = Directory.GetCurrentDirectory();
+                Directory.SetCurrentDirectory(directory);
+                try
+                {
+                    var exitCode = await Program.Main([
+                        "-t", "template.hbs",
+                        "-s", "source.json",
+                        "-r", "json"
+                    ]);
+
+                    Assert.That(exitCode, Is.Zero, message: ReadErrorStream());
+                    Assert.That(ReadOutputStream(), Is.EqualTo("Ada Lovelace"));
+                }
+                finally
+                {
+                    Directory.SetCurrentDirectory(originalCurrentDirectory);
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(directory))
+                    Directory.Delete(directory, true);
+            }
+        });
+
+    [Test]
+    [NonParallelizable]
+    public async Task Main_Render_WithRegisteredThrowingExtension_Fails()
+        => await ExecuteWithIsolatedRegistry(async registryPath =>
+        {
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.cli.testing.throwing",
+                Name = "Cli Testing Throwing Extension",
+                Assembly = typeof(Extensions.PipelineHookForE2eTests).Assembly.Location,
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var exitCode = await Program.Main([
+                "-t", "template/employees.hbs",
+                "-s", "data/employees.json",
+                "-r", "json"
+            ]);
+
+            Assert.That(exitCode, Is.Not.Zero);
+            Assert.That(ReadErrorStream(), Does.Contain("hook was applied"));
+        });
+
+    [Test]
+    [NonParallelizable]
+    public async Task Main_Render_WithDisabledExtension_DoesNotApplyHook()
+        => await ExecuteWithIsolatedRegistry(async registryPath =>
+        {
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "didot.cli.testing.extension",
+                Name = "Cli Testing Extension",
+                Assembly = typeof(Extensions.PipelineHookForE2eTests).Assembly.Location,
+                Enabled = false,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var exitCode = await Program.Main([
+                "-t", "template/employees.hbs",
+                "-s", "data/employees.json",
+                "-r", "json"
+            ]);
+
+            Assert.That(exitCode, Is.Zero, message: ReadErrorStream());
+
+            var expected = File.ReadAllText(Path.Combine("Expectation", "employees.txt")).Standardize();
+            Assert.That(ReadOutputStream(), Is.EqualTo(expected));
+        });
+
+    [Test]
+    [NonParallelizable]
+    public async Task Main_Render_WithMissingExtensionSource_FailsWithDiagnosticCode()
+        => await ExecuteWithIsolatedRegistry(async registryPath =>
+        {
+            var repository = new Cli.InstallationExtensionRegistryRepository(registryPath);
+            repository.Register(new Cli.ExtensionRegistryEntry
+            {
+                Id = "missing.extension",
+                Name = "Missing extension",
+                Assembly = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll"),
+                Enabled = true,
+                Version = "1.0.0",
+                RegisteredAt = DateTimeOffset.UtcNow,
+            });
+
+            var args = new[]
+            {
+                "-t", "template/employees.hbs",
+                "-s", "data/employees.json",
+                "-r", "json"
+            };
+
+            var exitCode = await Program.Main(args);
+
+            Assert.That(exitCode, Is.EqualTo((int)Cli.CliExitCode.NotFound));
+            Assert.That(ReadErrorStream(), Does.Contain("[ExtensionSourceNotFoundException]"));
+        });
 
     [Test, Combinatorial]
     public async Task Main_StdInStdOut_Successful(

--- a/testing/Didot.Cli.Testing/RenderOptions/EngineExtensionTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/EngineExtensionTests.cs
@@ -30,8 +30,9 @@ public class EngineExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string> { "--template=file1.txt", "--stdin", "--parser=json" };
-        args.AddRange(additionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        var args = (new[] { "--template=file1.txt", "--stdin", "--parser=json" })
+            .Concat(additionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .ToArray();
 
         var result = command.Parse(args);
 
@@ -51,8 +52,9 @@ public class EngineExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string> { "--template=file1.txt", "--stdin", "--parser=json" };
-        args.AddRange(additionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        var args = (new[] { "--template=file1.txt", "--stdin", "--parser=json" })
+            .Concat(additionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .ToArray();
 
         var result = command.Parse(args);
 

--- a/testing/Didot.Cli.Testing/RenderOptions/OutputTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/OutputTests.cs
@@ -18,8 +18,9 @@ public class OutputTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string> { "--template=file1.txt", "--stdin", "--parser=json" };
-        args.AddRange(optionArray);
+        var args = (new[] { "--template=file1.txt", "--stdin", "--parser=json" })
+            .Concat(optionArray)
+            .ToArray();
 
         var result = command.Parse(args);
 

--- a/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
@@ -15,7 +15,7 @@ public class ParserExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
+        var args = new[] { "--template=file1.txt", "--stdin", "--parser=json" };
 
         var result = command.Parse(args);
 
@@ -30,7 +30,7 @@ public class ParserExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
+        var args = new[] { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
 
         var result = command.Parse(args);
 
@@ -52,8 +52,9 @@ public class ParserExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new List<string>() { "--template=file1.txt", "--stdin", "--parser=json" };
-        args.AddRange(additionalArgs);
+        var args = (new[] { "--template=file1.txt", "--stdin", "--parser=json" })
+            .Concat(additionalArgs)
+            .ToArray();
 
         var result = command.Parse(args);
 

--- a/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
+++ b/testing/Didot.Cli.Testing/RenderOptions/ParserExtensionTests.cs
@@ -30,7 +30,9 @@ public class ParserExtensionTests
     {
         var options = new Cli.RenderOptions();
         var command = new RenderCommand(options);
-        var args = new[] { "--template=file1.txt", "--stdin", "--parser=json", additionalArgs };
+        var baseArgs = new[] { "--template=file1.txt", "--stdin", "--parser=json" };
+        var splitAdditionalArgs = additionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var args = baseArgs.Concat(splitAdditionalArgs).ToArray();
 
         var result = command.Parse(args);
 

--- a/testing/Didot.Core.Testing/PipelineExtensionHookTests.cs
+++ b/testing/Didot.Core.Testing/PipelineExtensionHookTests.cs
@@ -1,0 +1,112 @@
+using Moq;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing;
+
+public class PipelineExtensionHookTests
+{
+    [Test]
+    public void Render_StringString_WithHook_EnrichesModel()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse(It.IsAny<string>())).Returns(new Dictionary<string, object>
+        {
+            ["firstName"] = "Albert",
+            ["lastName"] = "Einstein",
+        });
+
+        var engine = new Mock<ITemplateEngine>();
+        engine
+            .Setup(e => e.Render(It.IsAny<string>(), It.IsAny<object>()))
+            .Callback<string, object>((_, wrappedModel) =>
+            {
+                var model = (IDictionary<string, object>)wrappedModel.GetType().GetProperty("model")!.GetValue(wrappedModel)!;
+                Assert.That(model["fullName"], Is.EqualTo("Albert Einstein"));
+            })
+            .Returns("ok");
+
+        var printer = new Printer(engine.Object)
+            .AddHook(new DelegateHook(model =>
+            {
+                var dict = (IDictionary<string, object>)model;
+                dict["fullName"] = $"{dict["firstName"]} {dict["lastName"]}";
+                return dict;
+            }));
+
+        var result = printer.Render("Hello {{model.fullName}}", "{}", parser.Object);
+
+        Assert.That(result, Is.EqualTo("ok"));
+    }
+
+    [Test]
+    public void Render_StringString_WithMultipleHooks_AppliesInOrder()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse(It.IsAny<string>())).Returns(new Dictionary<string, object>
+        {
+            ["value"] = 1,
+        });
+
+        var executionOrder = new List<string>();
+
+        var engine = new Mock<ITemplateEngine>();
+        engine
+            .Setup(e => e.Render(It.IsAny<string>(), It.IsAny<object>()))
+            .Callback<string, object>((_, wrappedModel) =>
+            {
+                var model = (IDictionary<string, object>)wrappedModel.GetType().GetProperty("model")!.GetValue(wrappedModel)!;
+                Assert.That(model["value"], Is.EqualTo(5));
+            })
+            .Returns("ok");
+
+        var firstHook = new DelegateHook(model =>
+        {
+            executionOrder.Add("hook-1");
+            var dict = (IDictionary<string, object>)model;
+            dict["value"] = (int)dict["value"] * 2;
+            return dict;
+        });
+
+        var secondHook = new DelegateHook(model =>
+        {
+            executionOrder.Add("hook-2");
+            var dict = (IDictionary<string, object>)model;
+            dict["value"] = (int)dict["value"] + 3;
+            return dict;
+        });
+
+        var printer = new Printer(engine.Object)
+            .AddHook(firstHook)
+            .AddHook(secondHook);
+
+        var result = printer.Render("x", "{}", parser.Object);
+
+        Assert.That(result, Is.EqualTo("ok"));
+        Assert.That(executionOrder, Is.EqualTo(new[] { "hook-1", "hook-2" }));
+    }
+
+    [Test]
+    public void Render_StringString_WhenHookReturnsNull_Throws()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse(It.IsAny<string>())).Returns(new Dictionary<string, object>());
+
+        var engine = new Mock<ITemplateEngine>();
+        var printer = new Printer(engine.Object)
+            .AddHook(new DelegateHook(_ => null!));
+
+        Assert.That(
+            () => printer.Render("x", "{}", parser.Object),
+            Throws.TypeOf<InvalidOperationException>());
+
+        engine.Verify(e => e.Render(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
+    private sealed class DelegateHook(Func<object, object> apply) : IPipelineExtensionHook
+    {
+        private Func<object, object> ApplyDelegate { get; } = apply;
+
+        public object Apply(object model)
+            => ApplyDelegate(model);
+    }
+}

--- a/testing/Didot.Core.Testing/RenderPipelineTests.cs
+++ b/testing/Didot.Core.Testing/RenderPipelineTests.cs
@@ -1,0 +1,115 @@
+using Moq;
+using NUnit.Framework;
+
+namespace Didot.Core.Testing;
+
+public class RenderPipelineTests
+{
+    [Test]
+    public void Execute_StringTemplateAndStringInput_ParsesThenRenders()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse("Name: World")).Returns(new Dictionary<string, object> { ["Name"] = "World" });
+
+        var engine = new Mock<ITemplateEngine>();
+        engine.Setup(e => e.Render("Hello {{model.Name}}", It.IsAny<object>())).Returns("Hello World");
+
+        var pipeline = new RenderPipeline();
+        var context = new RenderPipelineContext
+        {
+            TemplateEngine = engine.Object,
+            Template = "Hello {{model.Name}}",
+            Inputs = new Dictionary<string, IModelInput>
+            {
+                [string.Empty] = new StringModelInput("Name: World", parser.Object)
+            },
+        };
+
+        pipeline.Execute(context);
+
+        Assert.That(context.Output, Is.EqualTo("Hello World"));
+        parser.Verify(p => p.Parse("Name: World"), Times.Once);
+        engine.Verify(e => e.Render("Hello {{model.Name}}", It.IsAny<object>()), Times.Once);
+    }
+
+    [Test]
+    public void Execute_WithMultipleHooks_AppliesHooksInOrder()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse("{}")).Returns(new Dictionary<string, object> { ["value"] = 2 });
+
+        var order = new List<string>();
+
+        var engine = new Mock<ITemplateEngine>();
+        engine
+            .Setup(e => e.Render(It.IsAny<string>(), It.IsAny<object>()))
+            .Callback<string, object>((_, wrappedModel) =>
+            {
+                var model = (IDictionary<string, object>)wrappedModel.GetType().GetProperty("model")!.GetValue(wrappedModel)!;
+                Assert.That(model["value"], Is.EqualTo(7));
+            })
+            .Returns("ok");
+
+        var context = new RenderPipelineContext
+        {
+            TemplateEngine = engine.Object,
+            Template = "ignored",
+            Inputs = new Dictionary<string, IModelInput>
+            {
+                [string.Empty] = new StringModelInput("{}", parser.Object)
+            },
+            Hooks =
+            [
+                new DelegateHook(model =>
+                {
+                    order.Add("hook-1");
+                    var dict = (IDictionary<string, object>)model;
+                    dict["value"] = (int)dict["value"] * 3;
+                    return dict;
+                }),
+                new DelegateHook(model =>
+                {
+                    order.Add("hook-2");
+                    var dict = (IDictionary<string, object>)model;
+                    dict["value"] = (int)dict["value"] + 1;
+                    return dict;
+                })
+            ]
+        };
+
+        new RenderPipeline().Execute(context);
+
+        Assert.That(context.Output, Is.EqualTo("ok"));
+        Assert.That(order, Is.EqualTo(new[] { "hook-1", "hook-2" }));
+    }
+
+    [Test]
+    public void Execute_WhenHookReturnsNull_Throws()
+    {
+        var parser = new Mock<ISourceParser>();
+        parser.Setup(p => p.Parse("{}")).Returns(new Dictionary<string, object>());
+
+        var engine = new Mock<ITemplateEngine>();
+        var context = new RenderPipelineContext
+        {
+            TemplateEngine = engine.Object,
+            Template = "ignored",
+            Inputs = new Dictionary<string, IModelInput>
+            {
+                [string.Empty] = new StringModelInput("{}", parser.Object)
+            },
+            Hooks = [new DelegateHook(_ => null!)]
+        };
+
+        Assert.That(() => new RenderPipeline().Execute(context), Throws.TypeOf<InvalidOperationException>());
+        engine.Verify(e => e.Render(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
+    private sealed class DelegateHook(Func<object, object> apply) : IPipelineExtensionHook
+    {
+        private Func<object, object> ApplyDelegate { get; } = apply;
+
+        public object Apply(object model)
+            => ApplyDelegate(model);
+    }
+}


### PR DESCRIPTION
[feat: pipeline extension hook](https://github.com/Seddryck/Didot/pull/375/commits/5ad38e4c46b6bbf082285ef2fe122a0c2bace519)
[feat: locate and register extensions](https://github.com/Seddryck/Didot/pull/375/commits/54d13db13abf05e7dcc01b6fa6bbd8b34e3e2879)
[feat: load and execute extension](https://github.com/Seddryck/Didot/pull/375/commits/cdd61196d262412a6a43c3debf8579e0a80dd933)
[docs: concept of extension, registration and development](https://github.com/Seddryck/Didot/pull/375/commits/f50edc2fd22ee4ccc1bc8a45b801f21bbf0f0e17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `didot extensions register <reference>` to register extension assemblies with an optional `--name`.
  * Runtime extension hooks can now modify the render model before template rendering (executed in registration order).
  * Added structured CLI exit codes and diagnostic error reporting for common extension load/registration failures.
* **Documentation**
  * Expanded extensions docs: how runtime hook loading works, how to register extensions, and how to develop them.
* **CLI Changes**
  * Made `--template` optional (no longer required for all command flows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->